### PR TITLE
Enable Bugsnag only on production

### DIFF
--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -1,3 +1,4 @@
 Bugsnag.configure do |config|
   config.api_key = "ba0c39df0e6cd8eb2f1bec106b8bc09c"
+  config.notify_release_stages = ["production"]
 end


### PR DESCRIPTION
When `config.notify_release_environments` is not set, Bugsnag notifies
us of errors occurring in all the Rails environments. This is
particularly problematic when doing TDD as our bug monitoring will get
filled with false positives.

Here's an example of my errors appearing in the `bugsnag` channel:

<img width="759" alt="screen shot 2017-08-20 at 3 31 41 pm" src="https://user-images.githubusercontent.com/1901520/29492877-c81851c0-85bc-11e7-9b58-9575a8e736a5.png">