### PR TITLE
Fix failing handle regexp

### DIFF
--- a/config/initializers/exercism.rb
+++ b/config/initializers/exercism.rb
@@ -1,6 +1,6 @@
 module Exercism
   module Magic
-    HandleRegexp = /^[a-zA-Z0-9-]+$/
+    HandleRegexp = /^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$/
   end
 end
 


### PR DESCRIPTION
When running the test suite on master, I noticed that
`test/models/user_test.rb:82` fails. I updated the regexp in order to
match the expectations described in the test.

Furthermore, I think failing tests on master suggests that we should add
a CI check before merging. What are your thoughts?