### PR TITLE
Fetch and sync track updates when a webhook comes in (V2)

### DIFF
--- a/app/controllers/webhooks/track_updates_controller.rb
+++ b/app/controllers/webhooks/track_updates_controller.rb
@@ -1,0 +1,19 @@
+class Webhooks::TrackUpdatesController < WebhooksController
+  MASTER_REF = "refs/heads/master"
+
+  def create
+    TrackUpdate.create(track: track) if pushed_to_master?
+
+    render json: {}, status: 200
+  end
+
+  private
+
+  def pushed_to_master?
+    params[:ref].eql? MASTER_REF
+  end
+
+  def track
+    Track.find_by!(slug: params[:repository][:name])
+  end
+end

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -1,0 +1,3 @@
+class WebhooksController < ApplicationController
+  protect_from_forgery with: :null_session
+end

--- a/app/jobs/fetch_track_update_job.rb
+++ b/app/jobs/fetch_track_update_job.rb
@@ -1,0 +1,26 @@
+class FetchTrackUpdateJob < ApplicationJob
+  attr_accessor :track_update_fetch_id
+
+  before_perform do |job|
+    track_update = TrackUpdate.find(job.arguments.first)
+
+    track_update_fetch = TrackUpdateFetch.create!(
+      track_update: track_update,
+      host: Socket.gethostname
+    )
+
+    job.track_update_fetch_id = track_update_fetch.id
+  end
+
+  after_perform do |job|
+    track_update_fetch = TrackUpdateFetch.find(job.track_update_fetch_id)
+
+    track_update_fetch.update!(completed_at: Time.current)
+  end
+
+  def perform(track_update_id)
+    track_update = TrackUpdate.find(track_update_id)
+
+    Git::FetchesTracks.fetch([track_update.track])
+  end
+end

--- a/app/jobs/sync_track_update_job.rb
+++ b/app/jobs/sync_track_update_job.rb
@@ -1,0 +1,13 @@
+class SyncTrackUpdateJob < ApplicationJob
+  after_perform do |job|
+    track_update = TrackUpdate.find(job.arguments.first)
+
+    track_update.update!(synced_at: Time.current)
+  end
+
+  def perform(track_update_id)
+    track_update = TrackUpdate.find(track_update_id)
+
+    Git::SyncsTracks.sync([track_update.track])
+  end
+end

--- a/app/models/cluster_config.rb
+++ b/app/models/cluster_config.rb
@@ -1,0 +1,5 @@
+module ClusterConfig
+  def self.num_webservers
+    Rails.application.config_for("cluster")["num_webservers"]
+  end
+end

--- a/app/models/track_update.rb
+++ b/app/models/track_update.rb
@@ -1,5 +1,6 @@
 class TrackUpdate < ApplicationRecord
   belongs_to :track
+  has_many :track_update_fetches
 
   validates :track, presence: true
 end

--- a/app/models/track_update.rb
+++ b/app/models/track_update.rb
@@ -1,0 +1,5 @@
+class TrackUpdate < ApplicationRecord
+  belongs_to :track
+
+  validates :track, presence: true
+end

--- a/app/models/track_update_fetch.rb
+++ b/app/models/track_update_fetch.rb
@@ -1,0 +1,6 @@
+class TrackUpdateFetch < ApplicationRecord
+  belongs_to :track_update
+
+  validates :track_update, presence: true
+  validates :host, presence: true
+end

--- a/app/services/git/fetches_tracks.rb
+++ b/app/services/git/fetches_tracks.rb
@@ -1,6 +1,7 @@
 class Git::FetchesTracks
 
   ERROR_BACKOFF_PERIOD = 10.seconds
+  TRACK_BACKOFF_PERIOD = 1.second
 
   def self.fetch(tracks)
     new(tracks).fetch
@@ -15,7 +16,7 @@ class Git::FetchesTracks
     fetch_website_content
     tracks.each do |track|
       fetch_track(track)
-      sleep 1.second
+      sleep TRACK_BACKOFF_PERIOD
     end
   end
 

--- a/app/services/git/fetches_tracks.rb
+++ b/app/services/git/fetches_tracks.rb
@@ -1,25 +1,26 @@
 class Git::FetchesTracks
 
-  QUIET_PERIOD = 30.seconds
   ERROR_BACKOFF_PERIOD = 10.seconds
 
-  def self.run
-    new.run
+  def self.fetch(tracks)
+    new(tracks).fetch
   end
 
-  def run
-    loop do
-      fetch_problem_specs
-      fetch_website_content
-      Track.find_each do |track|
-        fetch(track)
-        sleep 1.second
-      end
-      sleep QUIET_PERIOD
+  def initialize(tracks)
+    @tracks = tracks
+  end
+
+  def fetch
+    fetch_problem_specs
+    fetch_website_content
+    tracks.each do |track|
+      fetch_track(track)
+      sleep 1.second
     end
   end
 
   private
+  attr_reader :tracks
 
   def fetch_problem_specs
     Rails.logger.info "Fetching problem specs"
@@ -41,7 +42,7 @@ class Git::FetchesTracks
     sleep ERROR_BACKOFF_PERIOD
   end
 
-  def fetch(track)
+  def fetch_track(track)
     repo_url = track.repo_url
     if repo_url.start_with?("http://example.com")
       Rails.logger.info "Skipping fetch for #{repo_url}"

--- a/app/services/git/fetches_updated_tracks.rb
+++ b/app/services/git/fetches_updated_tracks.rb
@@ -1,0 +1,44 @@
+class Git::FetchesUpdatedTracks
+
+  QUIET_PERIOD = 30.seconds
+
+  def self.run
+    new.run
+  end
+
+  def self.fetch
+    new.fetch
+  end
+
+  def run
+    loop do
+      fetch
+      sleep QUIET_PERIOD
+    end
+  end
+
+  def fetch
+    find_track_update
+    fetch_track_update if track_update
+  end
+
+  private
+
+  attr_reader :track_update, :track_update_fetch
+
+  def find_track_update
+   @track_update = TrackUpdate.
+     includes(:track_update_fetches).
+     where(synced_at: nil).
+     find_by(track_update_fetches: { track_update_id: nil }) ||
+     TrackUpdate.
+     includes(:track_update_fetches).
+     where(synced_at: nil).
+     where.not(track_update_fetches: { host: Socket.gethostname }).
+     first
+  end
+
+  def fetch_track_update
+    FetchTrackUpdateJob.perform_later(track_update.id)
+  end
+end

--- a/app/services/git/fetches_updated_tracks.rb
+++ b/app/services/git/fetches_updated_tracks.rb
@@ -27,15 +27,22 @@ class Git::FetchesUpdatedTracks
   attr_reader :track_update, :track_update_fetch
 
   def find_track_update
-   @track_update = TrackUpdate.
-     includes(:track_update_fetches).
-     where(synced_at: nil).
-     find_by(track_update_fetches: { track_update_id: nil }) ||
-     TrackUpdate.
-     includes(:track_update_fetches).
-     where(synced_at: nil).
-     where.not(track_update_fetches: { host: Socket.gethostname }).
-     first
+    @track_update = track_updates_without_fetches || track_updates_not_fetched
+  end
+
+  def track_updates_without_fetches
+    TrackUpdate.
+      includes(:track_update_fetches).
+      where(synced_at: nil).
+      find_by(track_update_fetches: { track_update_id: nil })
+  end
+
+  def track_updates_not_fetched
+    TrackUpdate.
+      includes(:track_update_fetches).
+      where(synced_at: nil).
+      where.not(track_update_fetches: { host: Socket.gethostname }).
+      first
   end
 
   def fetch_track_update

--- a/app/services/git/syncs_tracks.rb
+++ b/app/services/git/syncs_tracks.rb
@@ -1,41 +1,24 @@
 class Git::SyncsTracks
-
   QUIET_PERIOD = 5.minutes
 
-  def self.sync
-    new(Git::StateDb.instance).sync
+  def self.sync(tracks)
+    new(tracks).sync
   end
 
-  attr_reader :state_db
-
-  def initialize(state_db)
-    @state_db = state_db
+  def initialize(tracks)
+    @tracks = tracks
   end
 
   def sync
-    loop do
-      puts "Syncing all tracks"
-      Track.find_each do |track|
-        sync_one(track)
-        sleep 10.seconds
-      end
-      sleep QUIET_PERIOD
-    end
+    puts "Syncing tracks"
+    tracks.each { |track| sync_track(track) }
+    ::Exercise.where(slug: "hello-world").update_all(auto_approve: true)
   end
 
   private
+  attr_reader :tracks
 
-  # def sync_outstanding
-  #   loop do
-  #     track = next_to_sync
-  #     puts "Next track to sync: #{track.to_s}"
-  #     break if track.nil?
-  #     sync_one(track)
-  #   end
-  # end
-
-  def sync_one(track)
-    return nil unless track
+  def sync_track(track)
     puts "Sync track #{track.id}"
     begin
       Git::SyncsTrack.sync!(track)
@@ -44,14 +27,4 @@ class Git::SyncsTracks
       puts e.backtrace
     end
   end
-
-  # def next_to_sync
-  #   next_job = state_db.stale_tracks_before.first
-  #   return nil if next_job.nil?
-  #   puts next_job
-  #   Track.find(next_job[:track_id])
-  # rescue ActiveRecord::RecordNotFound => e
-  #   state_db.delete_id(next_job[:track_id])
-  # end
-
 end

--- a/app/services/git/syncs_updated_tracks.rb
+++ b/app/services/git/syncs_updated_tracks.rb
@@ -34,7 +34,7 @@ class Git::SyncsUpdatedTracks
       where(synced_at: nil).
       where.not(track_update_fetches: { completed_at: nil }).
       group("track_update_fetches.id").
-      having("count(track_update_id) = #{ENV["NUM_WEBSERVERS"]}").
+      having("count(track_update_id) = #{ClusterConfig.num_webservers}").
       first
   end
 

--- a/app/services/git/syncs_updated_tracks.rb
+++ b/app/services/git/syncs_updated_tracks.rb
@@ -39,6 +39,6 @@ class Git::SyncsUpdatedTracks
   end
 
   def sync_track_update
-    SyncTrackUpdateJob.perform_later(track_update)
+    SyncTrackUpdateJob.perform_later(track_update.id)
   end
 end

--- a/app/services/git/syncs_updated_tracks.rb
+++ b/app/services/git/syncs_updated_tracks.rb
@@ -1,0 +1,44 @@
+class Git::SyncsUpdatedTracks
+  QUIET_PERIOD = 10.seconds
+
+  def self.run
+    new.run
+  end
+
+  def self.sync
+    new.sync
+  end
+
+  def run
+    loop do
+      sync
+      puts "Sleeping"
+      sleep QUIET_PERIOD
+    end
+  end
+
+  def sync
+    find_track_update
+    if track_update
+      puts "Syncing outstanding tracks"
+      sync_track_update
+    end
+  end
+
+  private
+  attr_reader :track_update
+
+  def find_track_update
+    @track_update = TrackUpdate.
+      joins(:track_update_fetches).
+      where(synced_at: nil).
+      where.not(track_update_fetches: { completed_at: nil }).
+      group("track_update_fetches.id").
+      having("count(track_update_id) = #{ENV["NUM_WEBSERVERS"]}").
+      first
+  end
+
+  def sync_track_update
+    SyncTrackUpdateJob.perform_later(track_update)
+  end
+end

--- a/config/cluster.yml
+++ b/config/cluster.yml
@@ -1,0 +1,5 @@
+development:
+  num_webservers: 1
+
+production:
+  num_webservers: 3

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,10 @@ Rails.application.routes.draw do
     resources :discussion_posts, only: [:create]
   end
 
+  namespace :webhooks do
+    resources :track_updates, only: [:create]
+  end
+
   devise_for :users, controllers: {
     sessions: 'sessions',
     registrations: 'registrations',

--- a/db/migrate/20170823065541_create_track_update.rb
+++ b/db/migrate/20170823065541_create_track_update.rb
@@ -1,0 +1,10 @@
+class CreateTrackUpdate < ActiveRecord::Migration[5.1]
+  def change
+    create_table :track_updates do |t|
+      t.belongs_to :track, foreign_key: true, null: false
+      t.timestamp :synced_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170823075632_create_track_update_fetches.rb
+++ b/db/migrate/20170823075632_create_track_update_fetches.rb
@@ -1,0 +1,13 @@
+class CreateTrackUpdateFetches < ActiveRecord::Migration[5.1]
+  def change
+    create_table :track_update_fetches do |t|
+      t.timestamp :completed_at
+      t.belongs_to :track_update, foreign_key: true, null: false
+      t.string :host, null: false
+
+      t.timestamps
+    end
+
+    add_index :track_update_fetches, [:track_update_id, :host], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170823065541) do
+ActiveRecord::Schema.define(version: 20170823075632) do
 
   create_table "auth_tokens", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint "user_id", null: false
@@ -243,6 +243,16 @@ ActiveRecord::Schema.define(version: 20170823065541) do
     t.index ["user_id"], name: "fk_rails_283ecc719a"
   end
 
+  create_table "track_update_fetches", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.timestamp "completed_at"
+    t.bigint "track_update_id", null: false
+    t.string "host", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["track_update_id", "host"], name: "index_track_update_fetches_on_track_update_id_and_host", unique: true
+    t.index ["track_update_id"], name: "index_track_update_fetches_on_track_update_id"
+  end
+
   create_table "track_updates", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint "track_id", null: false
     t.timestamp "synced_at"
@@ -328,6 +338,7 @@ ActiveRecord::Schema.define(version: 20170823065541) do
   add_foreign_key "testimonials", "tracks"
   add_foreign_key "track_mentorships", "tracks"
   add_foreign_key "track_mentorships", "users"
+  add_foreign_key "track_update_fetches", "track_updates"
   add_foreign_key "track_updates", "tracks"
   add_foreign_key "user_tracks", "tracks"
   add_foreign_key "user_tracks", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170819200230) do
+ActiveRecord::Schema.define(version: 20170823065541) do
 
   create_table "auth_tokens", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.bigint "user_id", null: false
@@ -243,6 +243,14 @@ ActiveRecord::Schema.define(version: 20170819200230) do
     t.index ["user_id"], name: "fk_rails_283ecc719a"
   end
 
+  create_table "track_updates", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.bigint "track_id", null: false
+    t.timestamp "synced_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["track_id"], name: "index_track_updates_on_track_id"
+  end
+
   create_table "tracks", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string "slug", null: false
     t.string "title", null: false
@@ -320,6 +328,7 @@ ActiveRecord::Schema.define(version: 20170819200230) do
   add_foreign_key "testimonials", "tracks"
   add_foreign_key "track_mentorships", "tracks"
   add_foreign_key "track_mentorships", "users"
+  add_foreign_key "track_updates", "tracks"
   add_foreign_key "user_tracks", "tracks"
   add_foreign_key "user_tracks", "users"
 end

--- a/lib/tasks/git.rake
+++ b/lib/tasks/git.rake
@@ -3,7 +3,7 @@ namespace :git do
     trap('SIGINT') { puts "Sync Processor interrupted"; exit }
     trap('SIGTERM') { puts "Sync Processor terminated"; exit }
     Rails.logger = Logger.new(STDOUT)
-    Git::SyncsTracks.sync
+    Git::SyncsUpdatedTracks.sync
   end
 
   task :fetch => :environment do

--- a/lib/tasks/git.rake
+++ b/lib/tasks/git.rake
@@ -3,7 +3,7 @@ namespace :git do
     trap('SIGINT') { puts "Sync Processor interrupted"; exit }
     trap('SIGTERM') { puts "Sync Processor terminated"; exit }
     Rails.logger = Logger.new(STDOUT)
-    Git::SyncsUpdatedTracks.sync
+    Git::SyncsUpdatedTracks.run
   end
 
   task :fetch => :environment do

--- a/lib/tasks/git.rake
+++ b/lib/tasks/git.rake
@@ -10,6 +10,6 @@ namespace :git do
     trap('SIGINT') { puts "Fetch Processor interrupted"; exit }
     trap('SIGTERM') { puts "Fetch Processor terminated"; exit }
     Rails.logger = Logger.new(STDOUT)
-    Git::FetchesTracks.run
+    Git::FetchesUpdatedTracks.run
   end
 end

--- a/test/controllers/webhooks/track_updates_controller_test.rb
+++ b/test/controllers/webhooks/track_updates_controller_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+class Webhooks::TrackUpdatesControllerTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
+  test "create should return 200" do
+    post webhooks_track_updates_path
+
+    assert_response 200
+  end
+
+  test "create should create a TrackUpdate record when pushed to master" do
+    webhook = load_json("test/fixtures/github/push_event.json")
+    webhook["ref"] = "refs/heads/master"
+    webhook["repository"]["name"] = "ruby"
+    track = create(:track, slug: "ruby")
+
+    post webhooks_track_updates_path, params: webhook
+
+    track_update = TrackUpdate.last
+    assert_equal track, track_update.track
+  end
+
+  test "create should not create a TrackUpdate when not pushed to master" do
+    webhook = load_json("test/fixtures/github/push_event.json")
+
+    post webhooks_track_updates_path, params: webhook
+
+    assert_nil TrackUpdate.last
+  end
+
+  private
+
+  def load_json(file)
+    JSON.parse(File.read(file))
+  end
+end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -126,4 +126,8 @@ FactoryGirl.define do
     user { create :user }
     track { create :track }
   end
+
+  factory :track_update do
+    track { create :track }
+  end
 end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -130,4 +130,9 @@ FactoryGirl.define do
   factory :track_update do
     track { create :track }
   end
+
+  factory :track_update_fetch do
+    track_update { create :track_update }
+    host "host-1"
+  end
 end

--- a/test/fixtures/github/push_event.json
+++ b/test/fixtures/github/push_event.json
@@ -1,0 +1,163 @@
+{
+  "ref": "refs/heads/changes",
+  "before": "9049f1265b7d61be4a8904a9a27120d2064dab3b",
+  "after": "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+  "created": false,
+  "deleted": false,
+  "forced": false,
+  "base_ref": null,
+  "compare": "https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f",
+  "commits": [
+    {
+      "id": "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+      "tree_id": "f9d2a07e9488b91af2641b26b9407fe22a451433",
+      "distinct": true,
+      "message": "Update README.md",
+      "timestamp": "2015-05-05T19:40:15-04:00",
+      "url": "https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+      "author": {
+        "name": "baxterthehacker",
+        "email": "baxterthehacker@users.noreply.github.com",
+        "username": "baxterthehacker"
+      },
+      "committer": {
+        "name": "baxterthehacker",
+        "email": "baxterthehacker@users.noreply.github.com",
+        "username": "baxterthehacker"
+      },
+      "added": [
+
+      ],
+      "removed": [
+
+      ],
+      "modified": [
+        "README.md"
+      ]
+    }
+  ],
+  "head_commit": {
+    "id": "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+    "tree_id": "f9d2a07e9488b91af2641b26b9407fe22a451433",
+    "distinct": true,
+    "message": "Update README.md",
+    "timestamp": "2015-05-05T19:40:15-04:00",
+    "url": "https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+    "author": {
+      "name": "baxterthehacker",
+      "email": "baxterthehacker@users.noreply.github.com",
+      "username": "baxterthehacker"
+    },
+    "committer": {
+      "name": "baxterthehacker",
+      "email": "baxterthehacker@users.noreply.github.com",
+      "username": "baxterthehacker"
+    },
+    "added": [
+
+    ],
+    "removed": [
+
+    ],
+    "modified": [
+      "README.md"
+    ]
+  },
+  "repository": {
+    "id": 35129377,
+    "name": "public-repo",
+    "full_name": "baxterthehacker/public-repo",
+    "owner": {
+      "name": "baxterthehacker",
+      "email": "baxterthehacker@users.noreply.github.com"
+    },
+    "private": false,
+    "html_url": "https://github.com/baxterthehacker/public-repo",
+    "description": "",
+    "fork": false,
+    "url": "https://github.com/baxterthehacker/public-repo",
+    "forks_url": "https://api.github.com/repos/baxterthehacker/public-repo/forks",
+    "keys_url": "https://api.github.com/repos/baxterthehacker/public-repo/keys{/key_id}",
+    "collaborators_url": "https://api.github.com/repos/baxterthehacker/public-repo/collaborators{/collaborator}",
+    "teams_url": "https://api.github.com/repos/baxterthehacker/public-repo/teams",
+    "hooks_url": "https://api.github.com/repos/baxterthehacker/public-repo/hooks",
+    "issue_events_url": "https://api.github.com/repos/baxterthehacker/public-repo/issues/events{/number}",
+    "events_url": "https://api.github.com/repos/baxterthehacker/public-repo/events",
+    "assignees_url": "https://api.github.com/repos/baxterthehacker/public-repo/assignees{/user}",
+    "branches_url": "https://api.github.com/repos/baxterthehacker/public-repo/branches{/branch}",
+    "tags_url": "https://api.github.com/repos/baxterthehacker/public-repo/tags",
+    "blobs_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/blobs{/sha}",
+    "git_tags_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/tags{/sha}",
+    "git_refs_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/refs{/sha}",
+    "trees_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/trees{/sha}",
+    "statuses_url": "https://api.github.com/repos/baxterthehacker/public-repo/statuses/{sha}",
+    "languages_url": "https://api.github.com/repos/baxterthehacker/public-repo/languages",
+    "stargazers_url": "https://api.github.com/repos/baxterthehacker/public-repo/stargazers",
+    "contributors_url": "https://api.github.com/repos/baxterthehacker/public-repo/contributors",
+    "subscribers_url": "https://api.github.com/repos/baxterthehacker/public-repo/subscribers",
+    "subscription_url": "https://api.github.com/repos/baxterthehacker/public-repo/subscription",
+    "commits_url": "https://api.github.com/repos/baxterthehacker/public-repo/commits{/sha}",
+    "git_commits_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/commits{/sha}",
+    "comments_url": "https://api.github.com/repos/baxterthehacker/public-repo/comments{/number}",
+    "issue_comment_url": "https://api.github.com/repos/baxterthehacker/public-repo/issues/comments{/number}",
+    "contents_url": "https://api.github.com/repos/baxterthehacker/public-repo/contents/{+path}",
+    "compare_url": "https://api.github.com/repos/baxterthehacker/public-repo/compare/{base}...{head}",
+    "merges_url": "https://api.github.com/repos/baxterthehacker/public-repo/merges",
+    "archive_url": "https://api.github.com/repos/baxterthehacker/public-repo/{archive_format}{/ref}",
+    "downloads_url": "https://api.github.com/repos/baxterthehacker/public-repo/downloads",
+    "issues_url": "https://api.github.com/repos/baxterthehacker/public-repo/issues{/number}",
+    "pulls_url": "https://api.github.com/repos/baxterthehacker/public-repo/pulls{/number}",
+    "milestones_url": "https://api.github.com/repos/baxterthehacker/public-repo/milestones{/number}",
+    "notifications_url": "https://api.github.com/repos/baxterthehacker/public-repo/notifications{?since,all,participating}",
+    "labels_url": "https://api.github.com/repos/baxterthehacker/public-repo/labels{/name}",
+    "releases_url": "https://api.github.com/repos/baxterthehacker/public-repo/releases{/id}",
+    "created_at": 1430869212,
+    "updated_at": "2015-05-05T23:40:12Z",
+    "pushed_at": 1430869217,
+    "git_url": "git://github.com/baxterthehacker/public-repo.git",
+    "ssh_url": "git@github.com:baxterthehacker/public-repo.git",
+    "clone_url": "https://github.com/baxterthehacker/public-repo.git",
+    "svn_url": "https://github.com/baxterthehacker/public-repo",
+    "homepage": null,
+    "size": 0,
+    "stargazers_count": 0,
+    "watchers_count": 0,
+    "language": null,
+    "has_issues": true,
+    "has_downloads": true,
+    "has_wiki": true,
+    "has_pages": true,
+    "forks_count": 0,
+    "mirror_url": null,
+    "open_issues_count": 0,
+    "forks": 0,
+    "open_issues": 0,
+    "watchers": 0,
+    "default_branch": "master",
+    "stargazers": 0,
+    "master_branch": "master"
+  },
+  "pusher": {
+    "name": "baxterthehacker",
+    "email": "baxterthehacker@users.noreply.github.com"
+  },
+  "sender": {
+    "login": "baxterthehacker",
+    "id": 6752317,
+    "avatar_url": "https://avatars.githubusercontent.com/u/6752317?v=3",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/baxterthehacker",
+    "html_url": "https://github.com/baxterthehacker",
+    "followers_url": "https://api.github.com/users/baxterthehacker/followers",
+    "following_url": "https://api.github.com/users/baxterthehacker/following{/other_user}",
+    "gists_url": "https://api.github.com/users/baxterthehacker/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/baxterthehacker/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/baxterthehacker/subscriptions",
+    "organizations_url": "https://api.github.com/users/baxterthehacker/orgs",
+    "repos_url": "https://api.github.com/users/baxterthehacker/repos",
+    "events_url": "https://api.github.com/users/baxterthehacker/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/baxterthehacker/received_events",
+    "type": "User",
+    "site_admin": false
+  }
+}

--- a/test/jobs/fetch_track_update_job_test.rb
+++ b/test/jobs/fetch_track_update_job_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class FetchTrackUpdateJobTest < ActiveJob::TestCase
+  test "records fetch before performing" do
+    Git::FetchesTracks.stubs(:fetch)
+    track_update = create(:track_update)
+    host_name = "host"
+    Socket.stubs(:gethostname).returns(host_name)
+
+    FetchTrackUpdateJob.perform_now(track_update.id)
+
+    track_update_fetch = TrackUpdateFetch.last
+    assert_equal host_name, track_update_fetch.host
+    assert_equal track_update, track_update_fetch.track_update
+  end
+
+  test "fetches a track update" do
+    track_update = create(:track_update)
+
+    Git::FetchesTracks.expects(:fetch).with([track_update.track])
+
+    FetchTrackUpdateJob.perform_now(track_update.id)
+  end
+
+  test "records fetch completion time after performing" do
+    Git::FetchesTracks.stubs(:fetch)
+    track_update = create(:track_update)
+    host_name = "host"
+    Socket.stubs(:gethostname).returns(host_name)
+
+    FetchTrackUpdateJob.perform_now(track_update.id)
+
+    track_update_fetch = TrackUpdateFetch.last
+    refute_nil track_update_fetch.completed_at
+  end
+end

--- a/test/jobs/sync_track_update_job_test.rb
+++ b/test/jobs/sync_track_update_job_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class SyncTrackUpdateJobTest < ActiveJob::TestCase
+  test "syncs a track update" do
+    track_update = create(:track_update)
+
+    Git::SyncsTracks.expects(:sync).with([track_update.track])
+
+    SyncTrackUpdateJob.perform_now(track_update.id)
+  end
+
+  test "records sync time after performing" do
+    Git::SyncsTracks.stubs(:sync)
+    track_update = create(:track_update)
+
+    SyncTrackUpdateJob.perform_now(track_update.id)
+
+    track_update.reload
+    refute_nil track_update.synced_at
+  end
+end

--- a/test/models/track_update_fetch_test.rb
+++ b/test/models/track_update_fetch_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class TrackUpdateFetchTest < ActiveSupport::TestCase
+  test "validates presence of track update" do
+    track_update_fetch = build(:track_update_fetch, track_update: nil)
+    refute track_update_fetch.valid?
+
+    track_update_fetch = build(:track_update_fetch, track_update: build(:track_update))
+    assert track_update_fetch.valid?
+  end
+
+  test "validates presence of host" do
+    track_update_fetch = build(:track_update_fetch, host: nil)
+    refute track_update_fetch.valid?
+
+    track_update_fetch = build(:track_update_fetch, host: "host-1")
+    assert track_update_fetch.valid?
+  end
+end

--- a/test/models/track_update_test.rb
+++ b/test/models/track_update_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+class TrackUpdateTest < ActiveSupport::TestCase
+  test "validates presence of track" do
+    track_update = build(:track_update, track: nil)
+    refute track_update.valid?
+
+    track_update = build(:track_update, track: build(:track))
+    assert track_update.valid?
+  end
+end

--- a/test/services/git/fetches_tracks_test.rb
+++ b/test/services/git/fetches_tracks_test.rb
@@ -1,0 +1,47 @@
+require 'test_helper'
+
+class Git::FetchesTracksTest < ActiveSupport::TestCase
+  test "fetches problem specifications" do
+    Git::WebsiteContent.stubs(:head).returns(stub(:fetch!))
+
+    repo = mock()
+    Git::ProblemSpecifications.expects(:head).returns(repo)
+    repo.expects(:fetch!)
+
+    Git::FetchesTracks.fetch([])
+  end
+
+  test "fetches website content" do
+    track = build_stubbed(:track)
+    Git::ProblemSpecifications.stubs(:head).returns(stub(:fetch!))
+
+    repo = mock()
+    Git::WebsiteContent.expects(:head).returns(repo)
+    repo.expects(:fetch!)
+
+    Git::FetchesTracks.fetch([])
+  end
+
+  test "fetches track when not from http://example.com" do
+    track = build_stubbed(:track, repo_url: "http://github.com/exercism/csharp")
+    Git::ProblemSpecifications.stubs(:head).returns(stub(:fetch!))
+    Git::WebsiteContent.stubs(:head).returns(stub(:fetch!))
+
+    repo = mock()
+    Git::ExercismRepo.expects(:new).with(track.repo_url).returns(repo)
+    repo.expects(:fetch!)
+    repo.stubs(:head)
+
+    Git::FetchesTracks.fetch([track])
+  end
+
+  test "does not fetch track when from http://example.com" do
+    track = build_stubbed(:track, repo_url: "http://example.com/repos/csharp")
+    Git::ProblemSpecifications.stubs(:head).returns(stub(:fetch!))
+    Git::WebsiteContent.stubs(:head).returns(stub(:fetch!))
+
+    Git::ExercismRepo.expects(:new).with(track.repo_url).never
+
+    Git::FetchesTracks.fetch([track])
+  end
+end

--- a/test/services/git/fetches_updated_tracks_test.rb
+++ b/test/services/git/fetches_updated_tracks_test.rb
@@ -1,0 +1,58 @@
+require 'test_helper'
+
+class Git::FetchesUpdatedTracksTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  test "does not fetch an already fetched track update" do
+    track_update = create(:track_update)
+    host_name = "host-1"
+    track_update_fetch = create(:track_update_fetch,
+                                track_update: track_update,
+                                host: host_name)
+    Socket.stubs(:gethostname).returns(host_name)
+
+    assert_no_enqueued_jobs do
+      Git::FetchesUpdatedTracks.fetch
+    end
+  end
+
+  test "does not fetch an already synced track update" do
+    track_update = create(:track_update, synced_at: Time.current)
+
+    assert_no_enqueued_jobs do
+      Git::FetchesUpdatedTracks.fetch
+    end
+  end
+
+  test "does not fetch an already synced track update with previous fetches" do
+    track_update = create(:track_update, synced_at: Time.current)
+    track_update_fetch = create(:track_update_fetch,
+                                track_update: track_update,
+                                host: "host-1")
+    Socket.stubs(:gethostname).returns("host-2")
+
+    assert_no_enqueued_jobs do
+      Git::FetchesUpdatedTracks.fetch
+    end
+  end
+
+  test "fetches a track update if no fetches by any host yet" do
+    track_update = create(:track_update, track_update_fetches: [])
+
+    assert_enqueued_with(job: FetchTrackUpdateJob, args: [track_update.id]) do
+      Git::FetchesUpdatedTracks.fetch
+    end
+  end
+
+  test "fetches a track update if not yet fetched by host" do
+    track_update = create(:track_update, track_update_fetches: [])
+    track_update_fetch = create(:track_update_fetch,
+                         track_update: track_update,
+                         host: "host-1")
+    Socket.stubs(:gethostname).returns("host-2")
+
+    assert_enqueued_with(job: FetchTrackUpdateJob, args: [track_update.id]) do
+      Git::FetchesUpdatedTracks.fetch
+    end
+  end
+end

--- a/test/services/git/sync_updated_tracks_test.rb
+++ b/test/services/git/sync_updated_tracks_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Git::SyncsUpdatedTracksTest < ActiveJob::TestCase
   test "syncs a fully fetched track update" do
-    ENV["NUM_WEBSERVERS"] = "1"
+    ClusterConfig.stubs(:num_webservers).returns(1)
     track_update = create(:track_update)
     create_list(:track_update_fetch,
                 1,
@@ -12,12 +12,10 @@ class Git::SyncsUpdatedTracksTest < ActiveJob::TestCase
     assert_enqueued_with(job: SyncTrackUpdateJob) do
       Git::SyncsUpdatedTracks.sync
     end
-
-    ENV["NUM_WEBSERVERS"] = nil
   end
 
   test "does not sync an unfetched track update" do
-    ENV["NUM_WEBSERVERS"] = "1"
+    ClusterConfig.stubs(:num_webservers).returns(1)
     track_update = create(:track_update)
     create_list(:track_update_fetch,
                 1,
@@ -27,12 +25,10 @@ class Git::SyncsUpdatedTracksTest < ActiveJob::TestCase
     assert_no_enqueued_jobs do
       Git::SyncsUpdatedTracks.sync
     end
-
-    ENV["NUM_WEBSERVERS"] = nil
   end
 
   test "does not sync a track update not fetched by all webservers" do
-    ENV["NUM_WEBSERVERS"] = "2"
+    ClusterConfig.stubs(:num_webservers).returns(2)
     track_update = create(:track_update)
     create_list(:track_update_fetch,
                 1,
@@ -42,12 +38,10 @@ class Git::SyncsUpdatedTracksTest < ActiveJob::TestCase
     assert_no_enqueued_jobs do
       Git::SyncsUpdatedTracks.sync
     end
-
-    ENV["NUM_WEBSERVERS"] = nil
   end
 
   test "does not sync a synced track update" do
-    ENV["NUM_WEBSERVERS"] = "1"
+    ClusterConfig.stubs(:num_webservers).returns(1)
     track_update = create(:track_update, synced_at: Time.current)
     create_list(:track_update_fetch,
                 1,
@@ -57,7 +51,5 @@ class Git::SyncsUpdatedTracksTest < ActiveJob::TestCase
     assert_no_enqueued_jobs do
       Git::SyncsUpdatedTracks.sync
     end
-
-    ENV["NUM_WEBSERVERS"] = nil
   end
 end

--- a/test/services/git/sync_updated_tracks_test.rb
+++ b/test/services/git/sync_updated_tracks_test.rb
@@ -1,0 +1,63 @@
+require 'test_helper'
+
+class Git::SyncsUpdatedTracksTest < ActiveJob::TestCase
+  test "syncs a fully fetched track update" do
+    ENV["NUM_WEBSERVERS"] = "1"
+    track_update = create(:track_update)
+    create_list(:track_update_fetch,
+                1,
+                track_update: track_update,
+                completed_at: Time.current)
+
+    assert_enqueued_with(job: SyncTrackUpdateJob) do
+      Git::SyncsUpdatedTracks.sync
+    end
+
+    ENV["NUM_WEBSERVERS"] = nil
+  end
+
+  test "does not sync an unfetched track update" do
+    ENV["NUM_WEBSERVERS"] = "1"
+    track_update = create(:track_update)
+    create_list(:track_update_fetch,
+                1,
+                track_update: track_update,
+                completed_at: nil)
+
+    assert_no_enqueued_jobs do
+      Git::SyncsUpdatedTracks.sync
+    end
+
+    ENV["NUM_WEBSERVERS"] = nil
+  end
+
+  test "does not sync a track update not fetched by all webservers" do
+    ENV["NUM_WEBSERVERS"] = "2"
+    track_update = create(:track_update)
+    create_list(:track_update_fetch,
+                1,
+                track_update: track_update,
+                completed_at: Time.current)
+
+    assert_no_enqueued_jobs do
+      Git::SyncsUpdatedTracks.sync
+    end
+
+    ENV["NUM_WEBSERVERS"] = nil
+  end
+
+  test "does not sync a synced track update" do
+    ENV["NUM_WEBSERVERS"] = "1"
+    track_update = create(:track_update, synced_at: Time.current)
+    create_list(:track_update_fetch,
+                1,
+                track_update: track_update,
+                completed_at: Time.current)
+
+    assert_no_enqueued_jobs do
+      Git::SyncsUpdatedTracks.sync
+    end
+
+    ENV["NUM_WEBSERVERS"] = nil
+  end
+end

--- a/test/services/git/syncs_tracks_test.rb
+++ b/test/services/git/syncs_tracks_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+class Git::SyncsTracksTest < ActiveSupport::TestCase
+  test "syncs tracks" do
+    track = create(:track)
+
+    Git::SyncsTrack.expects(:sync!).with(track)
+
+    Git::SyncsTracks.sync([track])
+  end
+end


### PR DESCRIPTION
## Description
This is a reimplementation of fetching and syncing track updates. This was done because the first PR didn't take into account of the following:

1. Track update fetches need to happen on all webservers. The previous PR only does it on the webserver that receives the webhook.
2. Syncing should only happen when all webservers have fetched the track update. The previous PR has no way to guarantee this.

## Solution
Taking the above into account, here is a summary of what this implements:

1. When a webhook comes in, a `TrackUpdate` model is created. The `TrackUpdate` model is only created when it is a push to master.
2. The webservers poll for a fetchable `TrackUpdate`. A `TrackUpdate` is fetchable if it has no associated `TrackUpdateFetch` records that matches the webserver's host name.
3. When the webserver fetches a `TrackUpdate`, a `TrackUpdateFetch` record is created recording the webserver's host name. After fetching, the same `TrackUpdateFetch` record is marked with the time it has been fetched.
4. The processor polls for a syncable `TrackUpdate`. A `TrackUpdate` is syncable if the `TrackUpdate` has fetched `TrackUpdateFetches` equal to the number of webservers. This is currently set as `ENV[NUM_WEBSERVERS]` on the processor.
5. After the processor syncs a `TrackUpdate`, the `TrackUpdate` record is marked with the time it has been synced.

## Discussion
1. Since we set `ENV[NUM_WEBSERVERS]` on the processor, we should find a way to update this when we add a new webserver. I think we can do this later.