### PR TITLE
Rename lisp to common-lisp

### DIFF
--- a/app/services/git/seeds_tracks.rb
+++ b/app/services/git/seeds_tracks.rb
@@ -7,7 +7,7 @@ class Git::SeedsTracks
     https://github.com/exercism/cpp
     https://github.com/exercism/clojure
     https://github.com/exercism/coffeescript
-    https://github.com/exercism/lisp
+    https://github.com/exercism/common-lisp
     https://github.com/exercism/crystal
     https://github.com/exercism/d
     https://github.com/exercism/delphi


### PR DESCRIPTION
This was done a while back in production, right around the time we started working on
the git importer.