### PR TITLE
Remove hyphens from solution uuids

### DIFF
--- a/app/models/solution.rb
+++ b/app/models/solution.rb
@@ -25,7 +25,12 @@ class Solution < ApplicationRecord
   end
 
   before_create do
-    self.uuid = SecureRandom.uuid
+    # Search engines derive meaning by using hyphens
+    # as word-boundaries in URLs. Since we use the
+    # solution UUID for URLs, we're removing the hyphen
+    # to remove any spurious, accidental, and arbitrary
+    # meaning.
+    self.uuid = SecureRandom.uuid.gsub('-', '')
   end
 
   def to_param

--- a/test/models/solution_test.rb
+++ b/test/models/solution_test.rb
@@ -13,4 +13,9 @@ class SolutionTest < ActiveSupport::TestCase
     assert_equal instructions, solution.instructions
     assert_equal test_suite, solution.test_suite
   end
+
+  test "uuid has no hyphens" do
+    solution = create :solution
+    refute solution.uuid.include?('-')
+  end
 end


### PR DESCRIPTION
Per our discussion about search engines and SEO.

I added a comment to the code, since this is context that cannot be understood by reading the code itself.