### PR TITLE
Fetch and sync repo updates when a webhook comes in (V3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@
 .byebug_history
 
 /app/assets/images/tmp
+
+server_identity

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ mysql -e "GRANT ALL PRIVILEGES ON exercism_reboot_development.* TO 'exercism_reb
 mysql -e "GRANT ALL PRIVILEGES ON exercism_reboot_test.* TO 'exercism_reboot'@'localhost'" -u root -p
 ```
 
+### Server identity
+
+```bash
+$ echo "host" > server_identity
+```
+
 ### Running the application
 
 Something like this will get a working webserver on http://localhost:3000.

--- a/app/controllers/webhooks/repo_updates_controller.rb
+++ b/app/controllers/webhooks/repo_updates_controller.rb
@@ -2,9 +2,11 @@ class Webhooks::RepoUpdatesController < WebhooksController
   MASTER_REF = "refs/heads/master"
 
   def create
-    RepoUpdate.create(slug: slug) if pushed_to_master?
+    return unless pushed_to_master?
 
-    render json: {}, status: 200
+    repo_update = RepoUpdate.new(slug: slug)
+
+    render json: {} if repo_update.save
   end
 
   private

--- a/app/controllers/webhooks/repo_updates_controller.rb
+++ b/app/controllers/webhooks/repo_updates_controller.rb
@@ -1,0 +1,19 @@
+class Webhooks::RepoUpdatesController < WebhooksController
+  MASTER_REF = "refs/heads/master"
+
+  def create
+    RepoUpdate.create(slug: slug) if pushed_to_master?
+
+    render json: {}, status: 200
+  end
+
+  private
+
+  def pushed_to_master?
+    params[:ref].eql? MASTER_REF
+  end
+
+  def slug
+    params.fetch(:repository).fetch(:name)
+  end
+end

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -1,0 +1,3 @@
+class WebhooksController < ApplicationController
+  protect_from_forgery with: :null_session
+end

--- a/app/jobs/fetch_repo_update_job.rb
+++ b/app/jobs/fetch_repo_update_job.rb
@@ -1,0 +1,26 @@
+class FetchRepoUpdateJob < ApplicationJob
+  attr_accessor :repo_update_fetch_id
+
+  before_perform do |job|
+    repo_update = RepoUpdate.find(job.arguments.first)
+
+    repo_update_fetch = RepoUpdateFetch.create!(
+      repo_update: repo_update,
+      host: Socket.gethostname
+    )
+
+    job.repo_update_fetch_id = repo_update_fetch.id
+  end
+
+  after_perform do |job|
+    repo_update_fetch = RepoUpdateFetch.find(job.repo_update_fetch_id)
+
+    repo_update_fetch.update!(completed_at: Time.current)
+  end
+
+  def perform(repo_update_id)
+    repo_update = RepoUpdate.find(repo_update_id)
+
+    Git::FetchesRepos.fetch([repo_update.repo])
+  end
+end

--- a/app/jobs/fetch_repo_update_job.rb
+++ b/app/jobs/fetch_repo_update_job.rb
@@ -6,7 +6,7 @@ class FetchRepoUpdateJob < ApplicationJob
 
     repo_update_fetch = RepoUpdateFetch.create!(
       repo_update: repo_update,
-      host: Socket.gethostname
+      host: ClusterConfig.server_identity
     )
 
     job.repo_update_fetch_id = repo_update_fetch.id

--- a/app/jobs/sync_repo_update_job.rb
+++ b/app/jobs/sync_repo_update_job.rb
@@ -1,0 +1,14 @@
+class SyncRepoUpdateJob < ApplicationJob
+  after_perform do |job|
+    repo_update = RepoUpdate.find(job.arguments.first)
+
+    repo_update.update!(synced_at: Time.current)
+  end
+
+  def perform(repo_update_id)
+    repo_update = RepoUpdate.find(repo_update_id)
+    track = Track.find_by(slug: repo_update.slug)
+
+    Git::SyncsTracks.sync([track]) if track
+  end
+end

--- a/app/models/cluster_config.rb
+++ b/app/models/cluster_config.rb
@@ -1,0 +1,5 @@
+module ClusterConfig
+  def self.num_webservers
+    Rails.application.config_for("cluster")["num_webservers"]
+  end
+end

--- a/app/models/cluster_config.rb
+++ b/app/models/cluster_config.rb
@@ -2,4 +2,14 @@ module ClusterConfig
   def self.num_webservers
     Rails.application.config_for("cluster")["num_webservers"]
   end
+
+  def self.server_identity
+    File.read(server_identity_file).chomp
+  end
+
+  def self.server_identity_file
+    Rails.application.config_for("cluster")["server_identity_file"]
+  end
+
+  private_class_method :server_identity_file
 end

--- a/app/models/git/exercism_repo.rb
+++ b/app/models/git/exercism_repo.rb
@@ -54,6 +54,10 @@ class Git::ExercismRepo < Git::RepoBase
     pattern.present?? Regexp.new(pattern) : /[eE]xample/
   end
 
+  def ==(other)
+    repo_url == other.repo_url
+  end
+
   private
 
   def read_about(commit)

--- a/app/models/git/problem_specifications.rb
+++ b/app/models/git/problem_specifications.rb
@@ -10,6 +10,10 @@ class Git::ProblemSpecifications < Git::RepoBase
     super
   end
 
+  def ==(other)
+    repo_url == other.repo_url
+  end
+
   def exercises
     Exercises.new(self, head_commit)
   end

--- a/app/models/git/website_content.rb
+++ b/app/models/git/website_content.rb
@@ -14,6 +14,10 @@ class Git::WebsiteContent < Git::RepoBase
     super
   end
 
+  def ==(other)
+    repo_url == other.repo_url
+  end
+
   def pages
     FolderReader.new(self, head_commit, 'pages')
   end

--- a/app/models/null_track.rb
+++ b/app/models/null_track.rb
@@ -1,0 +1,4 @@
+class NullTrack
+  def repo
+  end
+end

--- a/app/models/repo_update.rb
+++ b/app/models/repo_update.rb
@@ -1,6 +1,8 @@
 class RepoUpdate < ApplicationRecord
   validates :slug, presence: true
 
+  has_many :repo_update_fetches, dependent: :destroy
+
   def repo
     case slug
     when "problem-specifications"

--- a/app/models/repo_update.rb
+++ b/app/models/repo_update.rb
@@ -1,3 +1,14 @@
 class RepoUpdate < ApplicationRecord
   validates :slug, presence: true
+
+  def repo
+    case slug
+    when "problem-specifications"
+      Git::ProblemSpecifications.head
+    when "website-copy"
+      Git::WebsiteContent.head
+    else
+      Track.find_by!(slug: slug).repo
+    end
+  end
 end

--- a/app/models/repo_update.rb
+++ b/app/models/repo_update.rb
@@ -1,0 +1,3 @@
+class RepoUpdate < ApplicationRecord
+  validates :slug, presence: true
+end

--- a/app/models/repo_update.rb
+++ b/app/models/repo_update.rb
@@ -1,5 +1,6 @@
 class RepoUpdate < ApplicationRecord
   validates :slug, presence: true
+  validates :repo, presence: true
 
   has_many :repo_update_fetches, dependent: :destroy
 
@@ -10,7 +11,13 @@ class RepoUpdate < ApplicationRecord
     when "website-copy"
       Git::WebsiteContent.head
     else
-      Track.find_by!(slug: slug).repo
+      track.repo
     end
+  end
+
+  private
+
+  def track
+    Track.find_by(slug: slug) || NullTrack.new
   end
 end

--- a/app/models/repo_update_fetch.rb
+++ b/app/models/repo_update_fetch.rb
@@ -1,0 +1,6 @@
+class RepoUpdateFetch < ApplicationRecord
+  belongs_to :repo_update
+
+  validates :repo_update, presence: true
+  validates :host, presence: true
+end

--- a/app/services/git/fetches_repos.rb
+++ b/app/services/git/fetches_repos.rb
@@ -1,4 +1,4 @@
-class Git::FetchesTracks
+class Git::FetchesRepos
 
   QUIET_PERIOD = 30.seconds
   ERROR_BACKOFF_PERIOD = 10.seconds

--- a/app/services/git/fetches_updated_repos.rb
+++ b/app/services/git/fetches_updated_repos.rb
@@ -1,0 +1,51 @@
+class Git::FetchesUpdatedRepos
+
+  QUIET_PERIOD = 30.seconds
+
+  def self.run
+    new.run
+  end
+
+  def self.fetch
+    new.fetch
+  end
+
+  def run
+    loop do
+      fetch
+      sleep QUIET_PERIOD
+    end
+  end
+
+  def fetch
+    find_repo_update
+    fetch_repo_update if repo_update
+  end
+
+  private
+
+  attr_reader :repo_update, :repo_update_fetch
+
+  def find_repo_update
+    @repo_update = repo_updates_without_fetches || repo_updates_not_fetched
+  end
+
+  def repo_updates_without_fetches
+    RepoUpdate.
+      includes(:repo_update_fetches).
+      where(synced_at: nil).
+      find_by(repo_update_fetches: { repo_update_id: nil })
+  end
+
+  def repo_updates_not_fetched
+    RepoUpdate.
+      includes(:repo_update_fetches).
+      where(synced_at: nil).
+      where.not(repo_update_fetches: { host: Socket.gethostname }).
+      first
+  end
+
+  def fetch_repo_update
+    FetchRepoUpdateJob.perform_later(repo_update.id)
+  end
+end

--- a/app/services/git/fetches_updated_repos.rb
+++ b/app/services/git/fetches_updated_repos.rb
@@ -41,7 +41,7 @@ class Git::FetchesUpdatedRepos
     RepoUpdate.
       includes(:repo_update_fetches).
       where(synced_at: nil).
-      where.not(repo_update_fetches: { host: Socket.gethostname }).
+      where.not(repo_update_fetches: { host: ClusterConfig.server_identity }).
       first
   end
 

--- a/app/services/git/syncs_tracks.rb
+++ b/app/services/git/syncs_tracks.rb
@@ -1,41 +1,24 @@
 class Git::SyncsTracks
-
   QUIET_PERIOD = 5.minutes
 
-  def self.sync
-    new(Git::StateDb.instance).sync
+  def self.sync(tracks)
+    new(tracks).sync
   end
 
-  attr_reader :state_db
-
-  def initialize(state_db)
-    @state_db = state_db
+  def initialize(tracks)
+    @tracks = tracks
   end
 
   def sync
-    loop do
-      puts "Syncing all tracks"
-      Track.find_each do |track|
-        sync_one(track)
-        sleep 10.seconds
-      end
-      sleep QUIET_PERIOD
-    end
+    puts "Syncing tracks"
+    tracks.each { |track| sync_track(track) }
+    ::Exercise.where(slug: "hello-world").update_all(auto_approve: true)
   end
 
   private
+  attr_reader :tracks
 
-  # def sync_outstanding
-  #   loop do
-  #     track = next_to_sync
-  #     puts "Next track to sync: #{track.to_s}"
-  #     break if track.nil?
-  #     sync_one(track)
-  #   end
-  # end
-
-  def sync_one(track)
-    return nil unless track
+  def sync_track(track)
     puts "Sync track #{track.id}"
     begin
       Git::SyncsTrack.sync!(track)
@@ -44,14 +27,4 @@ class Git::SyncsTracks
       puts e.backtrace
     end
   end
-
-  # def next_to_sync
-  #   next_job = state_db.stale_tracks_before.first
-  #   return nil if next_job.nil?
-  #   puts next_job
-  #   Track.find(next_job[:track_id])
-  # rescue ActiveRecord::RecordNotFound => e
-  #   state_db.delete_id(next_job[:track_id])
-  # end
-
 end

--- a/app/services/git/syncs_updated_repos.rb
+++ b/app/services/git/syncs_updated_repos.rb
@@ -1,0 +1,44 @@
+class Git::SyncsUpdatedRepos
+  QUIET_PERIOD = 10.seconds
+
+  def self.run
+    new.run
+  end
+
+  def self.sync
+    new.sync
+  end
+
+  def run
+    loop do
+      sync
+      puts "Sleeping"
+      sleep QUIET_PERIOD
+    end
+  end
+
+  def sync
+    find_repo_update
+    if repo_update
+      puts "Syncing outstanding repos"
+      sync_repo_update
+    end
+  end
+
+  private
+  attr_reader :repo_update
+
+  def find_repo_update
+    @repo_update = RepoUpdate.
+      joins(:repo_update_fetches).
+      where(synced_at: nil).
+      where.not(repo_update_fetches: { completed_at: nil }).
+      group("repo_update_fetches.id").
+      having("count(repo_update_id) = #{ClusterConfig.num_webservers}").
+      first
+  end
+
+  def sync_repo_update
+    SyncRepoUpdateJob.perform_later(repo_update.id)
+  end
+end

--- a/config/cluster.yml
+++ b/config/cluster.yml
@@ -1,5 +1,10 @@
 development:
   num_webservers: 1
+  server_identity_file: server_identity
 
 production:
   num_webservers: 2
+  server_identity_file: /etc/exercism/server_identity
+
+test:
+  server_identity_file: test/fixtures/server_identity

--- a/config/cluster.yml
+++ b/config/cluster.yml
@@ -1,0 +1,5 @@
+development:
+  num_webservers: 1
+
+production:
+  num_webservers: 2

--- a/config/initializers/cluster_config.rb
+++ b/config/initializers/cluster_config.rb
@@ -1,0 +1,7 @@
+server_identity_file = Rails.
+  application.
+  config_for("cluster")["server_identity_file"]
+
+unless File.exist?(server_identity_file)
+  raise "Server identity file isn't setup! Please see README.md"
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,10 @@ Rails.application.routes.draw do
     resources :discussion_posts, only: [:create]
   end
 
+  namespace :webhooks do
+    resources :repo_updates, only: [:create]
+  end
+
   devise_for :users, controllers: {
     sessions: 'sessions',
     registrations: 'registrations',

--- a/db/migrate/20170823065541_create_repo_update.rb
+++ b/db/migrate/20170823065541_create_repo_update.rb
@@ -1,0 +1,10 @@
+class CreateRepoUpdate < ActiveRecord::Migration[5.1]
+  def change
+    create_table :repo_updates do |t|
+      t.timestamp :synced_at
+      t.string :slug, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170823075632_create_repo_update_fetches.rb
+++ b/db/migrate/20170823075632_create_repo_update_fetches.rb
@@ -1,0 +1,13 @@
+class CreateRepoUpdateFetches < ActiveRecord::Migration[5.1]
+  def change
+    create_table :repo_update_fetches do |t|
+      t.timestamp :completed_at
+      t.belongs_to :repo_update, foreign_key: true, null: false
+      t.string :host, null: false
+
+      t.timestamps
+    end
+
+    add_index :repo_update_fetches, [:repo_update_id, :host], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -177,6 +177,16 @@ ActiveRecord::Schema.define(version: 20170825173701) do
     t.index ["user_id"], name: "fk_rails_9f02fc96a0"
   end
 
+  create_table "repo_update_fetches", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+    t.timestamp "completed_at"
+    t.bigint "repo_update_id", null: false
+    t.string "host", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["repo_update_id", "host"], name: "index_repo_update_fetches_on_repo_update_id_and_host", unique: true
+    t.index ["repo_update_id"], name: "index_repo_update_fetches_on_repo_update_id"
+  end
+
   create_table "repo_updates", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.timestamp "synced_at"
     t.string "slug", null: false
@@ -329,6 +339,7 @@ ActiveRecord::Schema.define(version: 20170825173701) do
   add_foreign_key "profiles", "users"
   add_foreign_key "reactions", "solutions"
   add_foreign_key "reactions", "users"
+  add_foreign_key "repo_update_fetches", "repo_updates"
   add_foreign_key "solution_mentorships", "solutions"
   add_foreign_key "solution_mentorships", "users"
   add_foreign_key "solutions", "exercises"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -177,6 +177,13 @@ ActiveRecord::Schema.define(version: 20170825173701) do
     t.index ["user_id"], name: "fk_rails_9f02fc96a0"
   end
 
+  create_table "repo_updates", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+    t.timestamp "synced_at"
+    t.string "slug", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "solution_mentorships", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.bigint "user_id", null: false
     t.bigint "solution_id", null: false

--- a/lib/tasks/git.rake
+++ b/lib/tasks/git.rake
@@ -3,7 +3,7 @@ namespace :git do
     trap('SIGINT') { puts "Sync Processor interrupted"; exit }
     trap('SIGTERM') { puts "Sync Processor terminated"; exit }
     Rails.logger = Logger.new(STDOUT)
-    Git::SyncsTracks.sync
+    Git::SyncsUpdatedRepos.run
   end
 
   task :fetch => :environment do

--- a/lib/tasks/git.rake
+++ b/lib/tasks/git.rake
@@ -10,6 +10,6 @@ namespace :git do
     trap('SIGINT') { puts "Fetch Processor interrupted"; exit }
     trap('SIGTERM') { puts "Fetch Processor terminated"; exit }
     Rails.logger = Logger.new(STDOUT)
-    Git::FetchesTracks.run
+    Git::FetchesUpdatedRepos.run
   end
 end

--- a/test/controllers/webhooks/repo_updates_controller_test.rb
+++ b/test/controllers/webhooks/repo_updates_controller_test.rb
@@ -3,13 +3,8 @@ require 'test_helper'
 class Webhooks::RepoUpdatesControllerTest < ActionDispatch::IntegrationTest
   include ActiveJob::TestHelper
 
-  test "create should return 200" do
-    post webhooks_repo_updates_path
-
-    assert_response 200
-  end
-
   test "create should create a RepoUpdate record when pushed to master" do
+    track = create(:track, slug: "ruby")
     webhook = load_json("test/fixtures/github/push_event.json")
     webhook["ref"] = "refs/heads/master"
     webhook["repository"]["name"] = "ruby"
@@ -22,6 +17,16 @@ class Webhooks::RepoUpdatesControllerTest < ActionDispatch::IntegrationTest
 
   test "create should not create a RepoUpdate when not pushed to master" do
     webhook = load_json("test/fixtures/github/push_event.json")
+
+    post webhooks_repo_updates_path, params: webhook
+
+    assert_nil RepoUpdate.last
+  end
+
+  test "create should not create a RepoUpdate when slug does not match" do
+    webhook = load_json("test/fixtures/github/push_event.json")
+    webhook["ref"] = "refs/heads/master"
+    webhook["repository"]["name"] = "unknown"
 
     post webhooks_repo_updates_path, params: webhook
 

--- a/test/controllers/webhooks/repo_updates_controller_test.rb
+++ b/test/controllers/webhooks/repo_updates_controller_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class Webhooks::RepoUpdatesControllerTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
+  test "create should return 200" do
+    post webhooks_repo_updates_path
+
+    assert_response 200
+  end
+
+  test "create should create a RepoUpdate record when pushed to master" do
+    webhook = load_json("test/fixtures/github/push_event.json")
+    webhook["ref"] = "refs/heads/master"
+    webhook["repository"]["name"] = "ruby"
+
+    post webhooks_repo_updates_path, params: webhook
+
+    repo_update = RepoUpdate.last
+    assert_equal "ruby", repo_update.slug
+  end
+
+  test "create should not create a RepoUpdate when not pushed to master" do
+    webhook = load_json("test/fixtures/github/push_event.json")
+
+    post webhooks_repo_updates_path, params: webhook
+
+    assert_nil RepoUpdate.last
+  end
+
+  private
+
+  def load_json(file)
+    JSON.parse(File.read(file))
+  end
+end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -126,4 +126,8 @@ FactoryGirl.define do
     user { create :user }
     track { create :track }
   end
+
+  factory :repo_update do
+    slug "go"
+  end
 end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -128,11 +128,11 @@ FactoryGirl.define do
   end
 
   factory :repo_update do
-    slug "go"
+    slug "website-copy"
   end
 
   factory :repo_update_fetch do
-    repo_update { create :repo_update }
+    repo_update { create(:repo_update) }
     host "host-1"
   end
 end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -130,4 +130,9 @@ FactoryGirl.define do
   factory :repo_update do
     slug "go"
   end
+
+  factory :repo_update_fetch do
+    repo_update { create :repo_update }
+    host "host-1"
+  end
 end

--- a/test/fixtures/github/push_event.json
+++ b/test/fixtures/github/push_event.json
@@ -1,0 +1,163 @@
+{
+  "ref": "refs/heads/changes",
+  "before": "9049f1265b7d61be4a8904a9a27120d2064dab3b",
+  "after": "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+  "created": false,
+  "deleted": false,
+  "forced": false,
+  "base_ref": null,
+  "compare": "https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f",
+  "commits": [
+    {
+      "id": "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+      "tree_id": "f9d2a07e9488b91af2641b26b9407fe22a451433",
+      "distinct": true,
+      "message": "Update README.md",
+      "timestamp": "2015-05-05T19:40:15-04:00",
+      "url": "https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+      "author": {
+        "name": "baxterthehacker",
+        "email": "baxterthehacker@users.noreply.github.com",
+        "username": "baxterthehacker"
+      },
+      "committer": {
+        "name": "baxterthehacker",
+        "email": "baxterthehacker@users.noreply.github.com",
+        "username": "baxterthehacker"
+      },
+      "added": [
+
+      ],
+      "removed": [
+
+      ],
+      "modified": [
+        "README.md"
+      ]
+    }
+  ],
+  "head_commit": {
+    "id": "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+    "tree_id": "f9d2a07e9488b91af2641b26b9407fe22a451433",
+    "distinct": true,
+    "message": "Update README.md",
+    "timestamp": "2015-05-05T19:40:15-04:00",
+    "url": "https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+    "author": {
+      "name": "baxterthehacker",
+      "email": "baxterthehacker@users.noreply.github.com",
+      "username": "baxterthehacker"
+    },
+    "committer": {
+      "name": "baxterthehacker",
+      "email": "baxterthehacker@users.noreply.github.com",
+      "username": "baxterthehacker"
+    },
+    "added": [
+
+    ],
+    "removed": [
+
+    ],
+    "modified": [
+      "README.md"
+    ]
+  },
+  "repository": {
+    "id": 35129377,
+    "name": "public-repo",
+    "full_name": "baxterthehacker/public-repo",
+    "owner": {
+      "name": "baxterthehacker",
+      "email": "baxterthehacker@users.noreply.github.com"
+    },
+    "private": false,
+    "html_url": "https://github.com/baxterthehacker/public-repo",
+    "description": "",
+    "fork": false,
+    "url": "https://github.com/baxterthehacker/public-repo",
+    "forks_url": "https://api.github.com/repos/baxterthehacker/public-repo/forks",
+    "keys_url": "https://api.github.com/repos/baxterthehacker/public-repo/keys{/key_id}",
+    "collaborators_url": "https://api.github.com/repos/baxterthehacker/public-repo/collaborators{/collaborator}",
+    "teams_url": "https://api.github.com/repos/baxterthehacker/public-repo/teams",
+    "hooks_url": "https://api.github.com/repos/baxterthehacker/public-repo/hooks",
+    "issue_events_url": "https://api.github.com/repos/baxterthehacker/public-repo/issues/events{/number}",
+    "events_url": "https://api.github.com/repos/baxterthehacker/public-repo/events",
+    "assignees_url": "https://api.github.com/repos/baxterthehacker/public-repo/assignees{/user}",
+    "branches_url": "https://api.github.com/repos/baxterthehacker/public-repo/branches{/branch}",
+    "tags_url": "https://api.github.com/repos/baxterthehacker/public-repo/tags",
+    "blobs_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/blobs{/sha}",
+    "git_tags_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/tags{/sha}",
+    "git_refs_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/refs{/sha}",
+    "trees_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/trees{/sha}",
+    "statuses_url": "https://api.github.com/repos/baxterthehacker/public-repo/statuses/{sha}",
+    "languages_url": "https://api.github.com/repos/baxterthehacker/public-repo/languages",
+    "stargazers_url": "https://api.github.com/repos/baxterthehacker/public-repo/stargazers",
+    "contributors_url": "https://api.github.com/repos/baxterthehacker/public-repo/contributors",
+    "subscribers_url": "https://api.github.com/repos/baxterthehacker/public-repo/subscribers",
+    "subscription_url": "https://api.github.com/repos/baxterthehacker/public-repo/subscription",
+    "commits_url": "https://api.github.com/repos/baxterthehacker/public-repo/commits{/sha}",
+    "git_commits_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/commits{/sha}",
+    "comments_url": "https://api.github.com/repos/baxterthehacker/public-repo/comments{/number}",
+    "issue_comment_url": "https://api.github.com/repos/baxterthehacker/public-repo/issues/comments{/number}",
+    "contents_url": "https://api.github.com/repos/baxterthehacker/public-repo/contents/{+path}",
+    "compare_url": "https://api.github.com/repos/baxterthehacker/public-repo/compare/{base}...{head}",
+    "merges_url": "https://api.github.com/repos/baxterthehacker/public-repo/merges",
+    "archive_url": "https://api.github.com/repos/baxterthehacker/public-repo/{archive_format}{/ref}",
+    "downloads_url": "https://api.github.com/repos/baxterthehacker/public-repo/downloads",
+    "issues_url": "https://api.github.com/repos/baxterthehacker/public-repo/issues{/number}",
+    "pulls_url": "https://api.github.com/repos/baxterthehacker/public-repo/pulls{/number}",
+    "milestones_url": "https://api.github.com/repos/baxterthehacker/public-repo/milestones{/number}",
+    "notifications_url": "https://api.github.com/repos/baxterthehacker/public-repo/notifications{?since,all,participating}",
+    "labels_url": "https://api.github.com/repos/baxterthehacker/public-repo/labels{/name}",
+    "releases_url": "https://api.github.com/repos/baxterthehacker/public-repo/releases{/id}",
+    "created_at": 1430869212,
+    "updated_at": "2015-05-05T23:40:12Z",
+    "pushed_at": 1430869217,
+    "git_url": "git://github.com/baxterthehacker/public-repo.git",
+    "ssh_url": "git@github.com:baxterthehacker/public-repo.git",
+    "clone_url": "https://github.com/baxterthehacker/public-repo.git",
+    "svn_url": "https://github.com/baxterthehacker/public-repo",
+    "homepage": null,
+    "size": 0,
+    "stargazers_count": 0,
+    "watchers_count": 0,
+    "language": null,
+    "has_issues": true,
+    "has_downloads": true,
+    "has_wiki": true,
+    "has_pages": true,
+    "forks_count": 0,
+    "mirror_url": null,
+    "open_issues_count": 0,
+    "forks": 0,
+    "open_issues": 0,
+    "watchers": 0,
+    "default_branch": "master",
+    "stargazers": 0,
+    "master_branch": "master"
+  },
+  "pusher": {
+    "name": "baxterthehacker",
+    "email": "baxterthehacker@users.noreply.github.com"
+  },
+  "sender": {
+    "login": "baxterthehacker",
+    "id": 6752317,
+    "avatar_url": "https://avatars.githubusercontent.com/u/6752317?v=3",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/baxterthehacker",
+    "html_url": "https://github.com/baxterthehacker",
+    "followers_url": "https://api.github.com/users/baxterthehacker/followers",
+    "following_url": "https://api.github.com/users/baxterthehacker/following{/other_user}",
+    "gists_url": "https://api.github.com/users/baxterthehacker/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/baxterthehacker/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/baxterthehacker/subscriptions",
+    "organizations_url": "https://api.github.com/users/baxterthehacker/orgs",
+    "repos_url": "https://api.github.com/users/baxterthehacker/repos",
+    "events_url": "https://api.github.com/users/baxterthehacker/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/baxterthehacker/received_events",
+    "type": "User",
+    "site_admin": false
+  }
+}

--- a/test/jobs/fetch_repo_update_job_test.rb
+++ b/test/jobs/fetch_repo_update_job_test.rb
@@ -6,7 +6,7 @@ class FetchRepoUpdateJobTest < ActiveJob::TestCase
     track = create(:track, slug: "ruby")
     repo_update = create(:repo_update, slug: "ruby")
     host_name = "host"
-    Socket.stubs(:gethostname).returns(host_name)
+    ClusterConfig.stubs(:server_identity).returns(host_name)
 
     FetchRepoUpdateJob.perform_now(repo_update.id)
 
@@ -29,7 +29,7 @@ class FetchRepoUpdateJobTest < ActiveJob::TestCase
     track = create(:track, slug: "ruby")
     repo_update = create(:repo_update, slug: "ruby")
     host_name = "host"
-    Socket.stubs(:gethostname).returns(host_name)
+    ClusterConfig.stubs(:server_identity).returns(host_name)
 
     FetchRepoUpdateJob.perform_now(repo_update.id)
 

--- a/test/jobs/fetch_repo_update_job_test.rb
+++ b/test/jobs/fetch_repo_update_job_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+class FetchRepoUpdateJobTest < ActiveJob::TestCase
+  test "records fetch before performing" do
+    Git::FetchesRepos.stubs(:fetch)
+    track = create(:track, slug: "ruby")
+    repo_update = create(:repo_update, slug: "ruby")
+    host_name = "host"
+    Socket.stubs(:gethostname).returns(host_name)
+
+    FetchRepoUpdateJob.perform_now(repo_update.id)
+
+    repo_update_fetch = RepoUpdateFetch.last
+    assert_equal host_name, repo_update_fetch.host
+    assert_equal repo_update, repo_update_fetch.repo_update
+  end
+
+  test "fetches a repo update" do
+    track = create(:track, slug: "ruby")
+    repo_update = create(:repo_update, slug: "ruby")
+
+    Git::FetchesRepos.expects(:fetch).with([repo_update.repo])
+
+    FetchRepoUpdateJob.perform_now(repo_update.id)
+  end
+
+  test "records fetch completion time after performing" do
+    Git::FetchesRepos.stubs(:fetch)
+    track = create(:track, slug: "ruby")
+    repo_update = create(:repo_update, slug: "ruby")
+    host_name = "host"
+    Socket.stubs(:gethostname).returns(host_name)
+
+    FetchRepoUpdateJob.perform_now(repo_update.id)
+
+    repo_update_fetch = RepoUpdateFetch.last
+    refute_nil repo_update_fetch.completed_at
+  end
+end

--- a/test/jobs/fetch_repo_update_job_test.rb
+++ b/test/jobs/fetch_repo_update_job_test.rb
@@ -3,8 +3,7 @@ require 'test_helper'
 class FetchRepoUpdateJobTest < ActiveJob::TestCase
   test "records fetch before performing" do
     Git::FetchesRepos.stubs(:fetch)
-    track = create(:track, slug: "ruby")
-    repo_update = create(:repo_update, slug: "ruby")
+    repo_update = create(:repo_update)
     host_name = "host"
     ClusterConfig.stubs(:server_identity).returns(host_name)
 
@@ -16,8 +15,7 @@ class FetchRepoUpdateJobTest < ActiveJob::TestCase
   end
 
   test "fetches a repo update" do
-    track = create(:track, slug: "ruby")
-    repo_update = create(:repo_update, slug: "ruby")
+    repo_update = create(:repo_update)
 
     Git::FetchesRepos.expects(:fetch).with([repo_update.repo])
 
@@ -26,8 +24,7 @@ class FetchRepoUpdateJobTest < ActiveJob::TestCase
 
   test "records fetch completion time after performing" do
     Git::FetchesRepos.stubs(:fetch)
-    track = create(:track, slug: "ruby")
-    repo_update = create(:repo_update, slug: "ruby")
+    repo_update = create(:repo_update)
     host_name = "host"
     ClusterConfig.stubs(:server_identity).returns(host_name)
 

--- a/test/jobs/sync_repo_update_job_test.rb
+++ b/test/jobs/sync_repo_update_job_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class SyncRepoUpdateJobTest < ActiveJob::TestCase
+  test "syncs tracks" do
+    track = create(:track, slug: "ruby")
+    repo_update = create(:repo_update, slug: "ruby")
+
+    Git::SyncsTracks.expects(:sync).with([track])
+
+    SyncRepoUpdateJob.perform_now(repo_update.id)
+  end
+
+  test "does not sync non-tracks" do
+    repo_update = create(:repo_update, slug: "website-copy")
+
+    Git::SyncsTracks.expects(:sync).never
+
+    SyncRepoUpdateJob.perform_now(repo_update.id)
+  end
+
+  test "records sync time after performing" do
+    repo_update = create(:repo_update)
+
+    SyncRepoUpdateJob.perform_now(repo_update.id)
+
+    repo_update.reload
+    refute_nil repo_update.synced_at
+  end
+end

--- a/test/models/cluster_config_test.rb
+++ b/test/models/cluster_config_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ClusterConfigTest < ActiveSupport::TestCase
+  test "gets the server identity from a file" do
+    assert_equal "hostname", ClusterConfig.server_identity
+  end
+end

--- a/test/models/git/exercism_repo_test.rb
+++ b/test/models/git/exercism_repo_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class Git::ExercismRepoTest < ActiveSupport::TestCase
+  test "equal when repo urls are the same" do
+    repo = Git::ExercismRepo.new("https://github.com/exercism/go")
+    another_repo = Git::ExercismRepo.new("https://github.com/exercism/go")
+
+    assert_equal repo, another_repo
+  end
+
+  test "unequal when repo urls are different" do
+    repo = Git::ExercismRepo.new("https://github.com/exercism/go")
+    another_repo = Git::ExercismRepo.new("https://github.com/exercism/cpp")
+
+    refute_equal repo, another_repo
+  end
+end

--- a/test/models/git/problem_specifications_test.rb
+++ b/test/models/git/problem_specifications_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class Git::ProblemSpecificationsTest < ActiveSupport::TestCase
+  test "equal when repo urls are the same" do
+    repo = Git::ProblemSpecifications.new("https://github.com/exercism/problem-specifications")
+    another_repo = Git::ProblemSpecifications.new("https://github.com/exercism/problem-specifications")
+
+    assert_equal repo, another_repo
+  end
+
+  test "unequal when repo urls are different" do
+    repo = Git::ProblemSpecifications.new("https://github.com/exercism/problem-specifications")
+    another_repo = Git::ProblemSpecifications.new("https://github.com/exercism/problem-specifications-v2")
+
+    refute_equal repo, another_repo
+  end
+end

--- a/test/models/git/website_content_test.rb
+++ b/test/models/git/website_content_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class Git::WebsiteContentTest < ActiveSupport::TestCase
+  test "equal when repo urls are the same" do
+    repo = Git::WebsiteContent.new("https://github.com/exercism/website-copy")
+    another_repo = Git::WebsiteContent.new("https://github.com/exercism/website-copy")
+
+    assert_equal repo, another_repo
+  end
+
+  test "unequal when repo urls are different" do
+    repo = Git::WebsiteContent.new("https://github.com/exercism/website-copy")
+    another_repo = Git::WebsiteContent.new("https://github.com/exercism/website-copy-v2")
+
+    refute_equal repo, another_repo
+  end
+end

--- a/test/models/null_track_test.rb
+++ b/test/models/null_track_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class NullTrackTest < ActiveSupport::TestCase
+  test "repo returns nil" do
+    assert_nil NullTrack.new.repo
+  end
+end

--- a/test/models/repo_update_fetch_test.rb
+++ b/test/models/repo_update_fetch_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class RepoUpdateFetchTest < ActiveSupport::TestCase
+  test "validates presence of repo update" do
+    repo_update_fetch = build(:repo_update_fetch, repo_update: nil)
+    refute repo_update_fetch.valid?
+
+    repo_update_fetch = build(:repo_update_fetch, repo_update: build(:repo_update))
+    assert repo_update_fetch.valid?
+  end
+
+  test "validates presence of host" do
+    repo_update_fetch = build(:repo_update_fetch, host: nil)
+    refute repo_update_fetch.valid?
+
+    repo_update_fetch = build(:repo_update_fetch, host: "host-1")
+    assert repo_update_fetch.valid?
+  end
+end

--- a/test/models/repo_update_test.rb
+++ b/test/models/repo_update_test.rb
@@ -12,23 +12,36 @@ class RepoUpdateTest < ActiveSupport::TestCase
   end
 
   test "repo returns a matching track's repo" do
-    repo_update = create(:repo_update, slug: "go")
     track = create(:track,
                    slug: "go",
                    repo_url: "https://github.com/exercism/go")
+    repo_update = build(:repo_update, slug: "go")
 
     assert_equal track.repo, repo_update.repo
   end
 
   test "repo returns the problem specs repo when slug matches" do
-    repo_update = create(:repo_update, slug: "problem-specifications")
+    repo_update = build(:repo_update, slug: "problem-specifications")
 
     assert_equal Git::ProblemSpecifications.head, repo_update.repo
   end
 
   test "repo returns the website copy repo when slug matches" do
-    repo_update = create(:repo_update, slug: "website-copy")
+    repo_update = build(:repo_update, slug: "website-copy")
 
     assert_equal Git::WebsiteContent.head, repo_update.repo
+  end
+
+  test "validates repo is valid" do
+    track = create(:track,
+                   slug: "go",
+                   repo_url: "https://github.com/exercism/go")
+    repo_update = build(:repo_update, slug: "go")
+
+    assert repo_update.valid?
+
+    repo_update.slug = "unknown"
+
+    refute repo_update.valid?
   end
 end

--- a/test/models/repo_update_test.rb
+++ b/test/models/repo_update_test.rb
@@ -10,4 +10,25 @@ class RepoUpdateTest < ActiveSupport::TestCase
 
     refute repo_update.valid?
   end
+
+  test "repo returns a matching track's repo" do
+    repo_update = create(:repo_update, slug: "go")
+    track = create(:track,
+                   slug: "go",
+                   repo_url: "https://github.com/exercism/go")
+
+    assert_equal track.repo, repo_update.repo
+  end
+
+  test "repo returns the problem specs repo when slug matches" do
+    repo_update = create(:repo_update, slug: "problem-specifications")
+
+    assert_equal Git::ProblemSpecifications.head, repo_update.repo
+  end
+
+  test "repo returns the website copy repo when slug matches" do
+    repo_update = create(:repo_update, slug: "website-copy")
+
+    assert_equal Git::WebsiteContent.head, repo_update.repo
+  end
 end

--- a/test/models/repo_update_test.rb
+++ b/test/models/repo_update_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class RepoUpdateTest < ActiveSupport::TestCase
+  test "validates presence of slug" do
+    repo_update = build_stubbed(:repo_update)
+
+    assert repo_update.valid?
+
+    repo_update.slug = ""
+
+    refute repo_update.valid?
+  end
+end

--- a/test/services/git/fetches_repos_test.rb
+++ b/test/services/git/fetches_repos_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class Git::FetchesReposTest < ActiveSupport::TestCase
+  test "fetches repos" do
+    repo = mock()
+    repo.stubs(:repo_url)
+    repo.stubs(:head)
+
+    repo.expects(:fetch!)
+
+    Git::FetchesRepos.fetch([repo])
+  end
+end

--- a/test/services/git/fetches_updated_repos_test.rb
+++ b/test/services/git/fetches_updated_repos_test.rb
@@ -9,7 +9,7 @@ class Git::FetchesUpdatedReposTest < ActiveSupport::TestCase
     repo_update_fetch = create(:repo_update_fetch,
                                 repo_update: repo_update,
                                 host: host_name)
-    Socket.stubs(:gethostname).returns(host_name)
+    ClusterConfig.stubs(:server_identity).returns(host_name)
 
     assert_no_enqueued_jobs do
       Git::FetchesUpdatedRepos.fetch
@@ -29,7 +29,7 @@ class Git::FetchesUpdatedReposTest < ActiveSupport::TestCase
     repo_update_fetch = create(:repo_update_fetch,
                                 repo_update: repo_update,
                                 host: "host-1")
-    Socket.stubs(:gethostname).returns("host-2")
+    ClusterConfig.stubs(:server_identity).returns("host-2")
 
     assert_no_enqueued_jobs do
       Git::FetchesUpdatedRepos.fetch
@@ -49,7 +49,7 @@ class Git::FetchesUpdatedReposTest < ActiveSupport::TestCase
     repo_update_fetch = create(:repo_update_fetch,
                          repo_update: repo_update,
                          host: "host-1")
-    Socket.stubs(:gethostname).returns("host-2")
+    ClusterConfig.stubs(:server_identity).returns("host-2")
 
     assert_enqueued_with(job: FetchRepoUpdateJob, args: [repo_update.id]) do
       Git::FetchesUpdatedRepos.fetch

--- a/test/services/git/fetches_updated_repos_test.rb
+++ b/test/services/git/fetches_updated_repos_test.rb
@@ -1,0 +1,58 @@
+require 'test_helper'
+
+class Git::FetchesUpdatedReposTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  test "does not fetch an already fetched repo update" do
+    repo_update = create(:repo_update)
+    host_name = "host-1"
+    repo_update_fetch = create(:repo_update_fetch,
+                                repo_update: repo_update,
+                                host: host_name)
+    Socket.stubs(:gethostname).returns(host_name)
+
+    assert_no_enqueued_jobs do
+      Git::FetchesUpdatedRepos.fetch
+    end
+  end
+
+  test "does not fetch an already synced repo update" do
+    repo_update = create(:repo_update, synced_at: Time.current)
+
+    assert_no_enqueued_jobs do
+      Git::FetchesUpdatedRepos.fetch
+    end
+  end
+
+  test "does not fetch an already synced repo update with previous fetches" do
+    repo_update = create(:repo_update, synced_at: Time.current)
+    repo_update_fetch = create(:repo_update_fetch,
+                                repo_update: repo_update,
+                                host: "host-1")
+    Socket.stubs(:gethostname).returns("host-2")
+
+    assert_no_enqueued_jobs do
+      Git::FetchesUpdatedRepos.fetch
+    end
+  end
+
+  test "fetches a repo update if no fetches by any host yet" do
+    repo_update = create(:repo_update, repo_update_fetches: [])
+
+    assert_enqueued_with(job: FetchRepoUpdateJob, args: [repo_update.id]) do
+      Git::FetchesUpdatedRepos.fetch
+    end
+  end
+
+  test "fetches a repo update if not yet fetched by host" do
+    repo_update = create(:repo_update, repo_update_fetches: [])
+    repo_update_fetch = create(:repo_update_fetch,
+                         repo_update: repo_update,
+                         host: "host-1")
+    Socket.stubs(:gethostname).returns("host-2")
+
+    assert_enqueued_with(job: FetchRepoUpdateJob, args: [repo_update.id]) do
+      Git::FetchesUpdatedRepos.fetch
+    end
+  end
+end

--- a/test/services/git/sync_updated_repos_test.rb
+++ b/test/services/git/sync_updated_repos_test.rb
@@ -1,0 +1,59 @@
+require 'test_helper'
+
+class Git::SyncsUpdatedReposTest < ActiveJob::TestCase
+  test "syncs a fully fetched track update" do
+    ClusterConfig.stubs(:num_webservers).returns(1)
+    track = create(:track, slug: "ruby")
+    repo_update = create(:repo_update, slug: "ruby")
+    create_list(:repo_update_fetch,
+                1,
+                repo_update: repo_update,
+                completed_at: Time.current)
+
+    assert_enqueued_with(job: SyncRepoUpdateJob) do
+      Git::SyncsUpdatedRepos.sync
+    end
+  end
+
+  test "does not sync an unfetched track update" do
+    ClusterConfig.stubs(:num_webservers).returns(1)
+    track = create(:track, slug: "ruby")
+    repo_update = create(:repo_update, slug: "ruby")
+    create_list(:repo_update_fetch,
+                1,
+                repo_update: repo_update,
+                completed_at: nil)
+
+    assert_no_enqueued_jobs do
+      Git::SyncsUpdatedRepos.sync
+    end
+  end
+
+  test "does not sync a track update not fetched by all webservers" do
+    ClusterConfig.stubs(:num_webservers).returns(2)
+    track = create(:track, slug: "ruby")
+    repo_update = create(:repo_update, slug: "ruby")
+    create_list(:repo_update_fetch,
+                1,
+                repo_update: repo_update,
+                completed_at: Time.current)
+
+    assert_no_enqueued_jobs do
+      Git::SyncsUpdatedRepos.sync
+    end
+  end
+
+  test "does not sync a synced track update" do
+    ClusterConfig.stubs(:num_webservers).returns(1)
+    track = create(:track, slug: "ruby")
+    repo_update = create(:repo_update, slug: "ruby", synced_at: Time.current)
+    create_list(:repo_update_fetch,
+                1,
+                repo_update: repo_update,
+                completed_at: Time.current)
+
+    assert_no_enqueued_jobs do
+      Git::SyncsUpdatedRepos.sync
+    end
+  end
+end

--- a/test/services/git/sync_updated_repos_test.rb
+++ b/test/services/git/sync_updated_repos_test.rb
@@ -3,8 +3,7 @@ require 'test_helper'
 class Git::SyncsUpdatedReposTest < ActiveJob::TestCase
   test "syncs a fully fetched track update" do
     ClusterConfig.stubs(:num_webservers).returns(1)
-    track = create(:track, slug: "ruby")
-    repo_update = create(:repo_update, slug: "ruby")
+    repo_update = create(:repo_update)
     create_list(:repo_update_fetch,
                 1,
                 repo_update: repo_update,
@@ -17,8 +16,7 @@ class Git::SyncsUpdatedReposTest < ActiveJob::TestCase
 
   test "does not sync an unfetched track update" do
     ClusterConfig.stubs(:num_webservers).returns(1)
-    track = create(:track, slug: "ruby")
-    repo_update = create(:repo_update, slug: "ruby")
+    repo_update = create(:repo_update)
     create_list(:repo_update_fetch,
                 1,
                 repo_update: repo_update,
@@ -31,8 +29,7 @@ class Git::SyncsUpdatedReposTest < ActiveJob::TestCase
 
   test "does not sync a track update not fetched by all webservers" do
     ClusterConfig.stubs(:num_webservers).returns(2)
-    track = create(:track, slug: "ruby")
-    repo_update = create(:repo_update, slug: "ruby")
+    repo_update = create(:repo_update)
     create_list(:repo_update_fetch,
                 1,
                 repo_update: repo_update,
@@ -45,8 +42,7 @@ class Git::SyncsUpdatedReposTest < ActiveJob::TestCase
 
   test "does not sync a synced track update" do
     ClusterConfig.stubs(:num_webservers).returns(1)
-    track = create(:track, slug: "ruby")
-    repo_update = create(:repo_update, slug: "ruby", synced_at: Time.current)
+    repo_update = create(:repo_update, synced_at: Time.current)
     create_list(:repo_update_fetch,
                 1,
                 repo_update: repo_update,

--- a/test/services/git/syncs_tracks_test.rb
+++ b/test/services/git/syncs_tracks_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+class Git::SyncsTracksTest < ActiveSupport::TestCase
+  test "syncs tracks" do
+    track = create(:track)
+
+    Git::SyncsTrack.expects(:sync!).with(track)
+
+    Git::SyncsTracks.sync([track])
+  end
+end


### PR DESCRIPTION
## Description
This is a reimplementation of fetching and syncing repo updates. This was done because the second PR didn't take into account of the following:

1. Pushes to `website-copy` and `problem-specifications` should also trigger fetching and syncing.
2. Server identities are accessible via `/etc/exercism/server-identity` on our servers.

## Solution
Taking the above into account, here is a summary of what this implements:

1. When a webhook comes in, a `RepoUpdate` model is created. The `RepoUpdate` model is only created when it is a push to master, and when the repository name equals a track slug, `website-content`, or `problem-specifications`.
2. The webservers poll for a fetchable `RepoUpdate`. A `RepoUpdate` is fetchable if it has no associated `RepoUpdateFetch` records that matches the webserver's host name.
3. When the webserver fetches a `RepoUpdate`, a `RepoUpdateFetch` record is created recording the webserver's host name. The host name is retrieved by reading the `/etc/exercism/server-identity` file. After fetching, the same `RepoUpdateFetch` record is marked with the time it has been fetched.
4. The processor polls for a syncable `RepoUpdate`. A `RepoUpdate` is syncable if the `RepoUpdate` has fetched `RepoUpdateFetches` equal to the number of webservers. This is currently set as `ClusterConfig.num_webservers` through a YAML file.
4.1 When the `RepoUpdate` is synced, an associated track for the `RepoUpdate` is checked. When a track is associated to the `RepoUpdate`, additional actions such as syncing exercises and maintainers are done. These actions aren't done when a `RepoUpdate` is associated to the `website-copy` or `problem-specifications` repos.
5. After the processor syncs a `RepoUpdate`, the `RepoUpdate` record is marked with the time it has been synced.