### PR TITLE
Use `perform_now` to fetch repos on webservers

### DIFF
--- a/app/services/git/fetches_updated_repos.rb
+++ b/app/services/git/fetches_updated_repos.rb
@@ -46,6 +46,6 @@ class Git::FetchesUpdatedRepos
   end
 
   def fetch_repo_update
-    FetchRepoUpdateJob.perform_later(repo_update.id)
+    FetchRepoUpdateJob.perform_now(repo_update.id)
   end
 end

--- a/test/services/git/fetches_updated_repos_test.rb
+++ b/test/services/git/fetches_updated_repos_test.rb
@@ -11,17 +11,17 @@ class Git::FetchesUpdatedReposTest < ActiveSupport::TestCase
                                 host: host_name)
     ClusterConfig.stubs(:server_identity).returns(host_name)
 
-    assert_no_enqueued_jobs do
-      Git::FetchesUpdatedRepos.fetch
-    end
+    FetchRepoUpdateJob.expects(:perform_now).never
+
+    Git::FetchesUpdatedRepos.fetch
   end
 
   test "does not fetch an already synced repo update" do
     repo_update = create(:repo_update, synced_at: Time.current)
 
-    assert_no_enqueued_jobs do
-      Git::FetchesUpdatedRepos.fetch
-    end
+    FetchRepoUpdateJob.expects(:perform_now).never
+
+    Git::FetchesUpdatedRepos.fetch
   end
 
   test "does not fetch an already synced repo update with previous fetches" do
@@ -31,17 +31,17 @@ class Git::FetchesUpdatedReposTest < ActiveSupport::TestCase
                                 host: "host-1")
     ClusterConfig.stubs(:server_identity).returns("host-2")
 
-    assert_no_enqueued_jobs do
-      Git::FetchesUpdatedRepos.fetch
-    end
+    FetchRepoUpdateJob.expects(:perform_now).never
+
+    Git::FetchesUpdatedRepos.fetch
   end
 
   test "fetches a repo update if no fetches by any host yet" do
     repo_update = create(:repo_update, repo_update_fetches: [])
 
-    assert_enqueued_with(job: FetchRepoUpdateJob, args: [repo_update.id]) do
-      Git::FetchesUpdatedRepos.fetch
-    end
+    FetchRepoUpdateJob.expects(:perform_now).with(repo_update.id)
+
+    Git::FetchesUpdatedRepos.fetch
   end
 
   test "fetches a repo update if not yet fetched by host" do
@@ -51,8 +51,8 @@ class Git::FetchesUpdatedReposTest < ActiveSupport::TestCase
                          host: "host-1")
     ClusterConfig.stubs(:server_identity).returns("host-2")
 
-    assert_enqueued_with(job: FetchRepoUpdateJob, args: [repo_update.id]) do
-      Git::FetchesUpdatedRepos.fetch
-    end
+    FetchRepoUpdateJob.expects(:perform_now).with(repo_update.id)
+
+    Git::FetchesUpdatedRepos.fetch
   end
 end


### PR DESCRIPTION
Since our fetching and syncing logic is dependent on the webserver's server identity. We must perform our repo fetches on the webservers themselves. Changing `perform_later` to `perform_now` should fix this problem.