### PR TITLE
Update repo sync sql

### DIFF
--- a/app/services/git/syncs_updated_repos.rb
+++ b/app/services/git/syncs_updated_repos.rb
@@ -33,7 +33,7 @@ class Git::SyncsUpdatedRepos
       joins(:repo_update_fetches).
       where(synced_at: nil).
       where.not(repo_update_fetches: { completed_at: nil }).
-      group("repo_update_fetches.id").
+      group("repo_update_id").
       having("count(repo_update_id) = #{ClusterConfig.num_webservers}").
       first
   end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -133,6 +133,6 @@ FactoryGirl.define do
 
   factory :repo_update_fetch do
     repo_update { create(:repo_update) }
-    host "host-1"
+    host { |n| "host-#{n}" }
   end
 end

--- a/test/services/git/sync_updated_repos_test.rb
+++ b/test/services/git/sync_updated_repos_test.rb
@@ -2,10 +2,10 @@ require 'test_helper'
 
 class Git::SyncsUpdatedReposTest < ActiveJob::TestCase
   test "syncs a fully fetched track update" do
-    ClusterConfig.stubs(:num_webservers).returns(1)
+    ClusterConfig.stubs(:num_webservers).returns(2)
     repo_update = create(:repo_update)
     create_list(:repo_update_fetch,
-                1,
+                2,
                 repo_update: repo_update,
                 completed_at: Time.current)
 


### PR DESCRIPTION
The old SQL for choosing repos to sync didn't retrieve repos which were completely fetched.