### PR TITLE
Fetch problem specs before syncing

### DIFF
--- a/app/services/git/syncs_tracks.rb
+++ b/app/services/git/syncs_tracks.rb
@@ -11,12 +11,25 @@ class Git::SyncsTracks
 
   def sync
     puts "Syncing tracks"
-    tracks.each { |track| sync_track(track) }
-    ::Exercise.where(slug: "hello-world").update_all(auto_approve: true)
+    fetch_problem_specs
+    sync_tracks
+    approve_hello_world_exercises
   end
 
   private
   attr_reader :tracks
+
+  def fetch_problem_specs
+    Git::ProblemSpecifications.head.fetch!
+  end
+
+  def sync_tracks
+    tracks.each { |track| sync_track(track) }
+  end
+
+  def approve_hello_world_exercises
+    ::Exercise.where(slug: "hello-world").update_all(auto_approve: true)
+  end
 
   def sync_track(track)
     puts "Sync track #{track.id}"

--- a/test/services/git/syncs_tracks_test.rb
+++ b/test/services/git/syncs_tracks_test.rb
@@ -1,7 +1,16 @@
 require 'test_helper'
 
 class Git::SyncsTracksTest < ActiveSupport::TestCase
+  test "fetches problem specs" do
+    repo = mock()
+    repo.expects(:fetch!)
+    Git::ProblemSpecifications.stubs(:head).returns(repo)
+
+    Git::SyncsTracks.sync([])
+  end
+
   test "syncs tracks" do
+    Git::ProblemSpecifications.stubs(:head).returns(stub(:fetch!))
     track = create(:track)
 
     Git::SyncsTrack.expects(:sync!).with(track)

--- a/test/services/git/syncs_tracks_test.rb
+++ b/test/services/git/syncs_tracks_test.rb
@@ -17,4 +17,15 @@ class Git::SyncsTracksTest < ActiveSupport::TestCase
 
     Git::SyncsTracks.sync([track])
   end
+
+  test "approves hello world exercises" do
+    Git::ProblemSpecifications.stubs(:head).returns(stub(:fetch!))
+    exercise = create(:exercise, slug: "hello-world", auto_approve: false)
+
+    Git::SyncsTracks.sync([])
+
+    exercise.reload
+
+    assert exercise.auto_approve?
+  end
 end


### PR DESCRIPTION
@ccare pointed out yesterday that we should fetch the problem specifications repo before syncing. This is because the sync process involves getting the standard exercise spec and description from the problem specifications repo.