### PR TITLE
Update repos at a regular interval

### DIFF
--- a/app/models/repo_update.rb
+++ b/app/models/repo_update.rb
@@ -1,4 +1,7 @@
 class RepoUpdate < ApplicationRecord
+  PROBLEM_SPEC_SLUG = "problem-specifications"
+  WEBSITE_COPY_SLUG = "website-copy"
+
   validates :slug, presence: true
   validates :repo, presence: true
 
@@ -6,9 +9,9 @@ class RepoUpdate < ApplicationRecord
 
   def repo
     case slug
-    when "problem-specifications"
+    when PROBLEM_SPEC_SLUG
       Git::ProblemSpecifications.head
-    when "website-copy"
+    when WEBSITE_COPY_SLUG
       Git::WebsiteContent.head
     else
       track.repo

--- a/app/services/git/updates_repos.rb
+++ b/app/services/git/updates_repos.rb
@@ -1,0 +1,27 @@
+class Git::UpdatesRepos
+  def self.update
+    new.update
+  end
+
+  def update
+    update_tracks
+    update_problem_specs
+    update_website_copy
+  end
+
+  private
+
+  def update_tracks
+    Track.find_each do |track|
+      RepoUpdate.create(slug: track.slug)
+    end
+  end
+
+  def update_problem_specs
+    RepoUpdate.create(slug: RepoUpdate::PROBLEM_SPEC_SLUG)
+  end
+
+  def update_website_copy
+    RepoUpdate.create(slug: RepoUpdate::WEBSITE_COPY_SLUG)
+  end
+end

--- a/lib/tasks/git.rake
+++ b/lib/tasks/git.rake
@@ -1,4 +1,8 @@
 namespace :git do
+  task :update_repos => :environment do
+    Git::UpdatesRepos.update
+  end
+
   task :sync => :environment do
     trap('SIGINT') { puts "Sync Processor interrupted"; exit }
     trap('SIGTERM') { puts "Sync Processor terminated"; exit }

--- a/test/services/git/updates_repos_test.rb
+++ b/test/services/git/updates_repos_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class Git::UpdatesReposTest < ActiveSupport::TestCase
+  test "creates repo update records to update repos" do
+    track = create(:track, slug: "cpp")
+
+    Git::UpdatesRepos.update
+
+    refute_nil RepoUpdate.find_by(slug: "cpp")
+    refute_nil RepoUpdate.find_by(slug: "problem-specifications")
+    refute_nil RepoUpdate.find_by(slug: "website-copy")
+  end
+end


### PR DESCRIPTION
Create `RepoUpdate` records to update tracks, problem specifications, and
website copy. `rake git:update_repos` will be ran at a regular interval via a cron job.