### PR TITLE
Validate website input field using HTML5 matchers

### DIFF
--- a/app/views/my/profile/edit.html.haml
+++ b/app/views/my/profile/edit.html.haml
@@ -25,7 +25,10 @@
         %h3 Elsewhere Online
         .field
           %i.fa.fa-globe
-          =f.text_field :website, placeholder: "Your website"
+          =f.url_field :website,
+            placeholder: "Your website",
+            pattern: "https?://.+",
+            title: "Please enter a URL starting with http:// or https://"
         .field.twitter
           %i.fa.fa-twitter
           =f.text_field :twitter, placeholder: "handle"


### PR DESCRIPTION
This PR adds validation to the website field in the "Edit Profile" modal.

## Screenshots
### Entering an invalid URL
<img width="454" alt="screen shot 2017-09-18 at 5 54 14 pm" src="https://user-images.githubusercontent.com/1901520/30537002-9d35da46-9c9a-11e7-9b02-5eff797b5efc.png">

This should fix https://github.com/exercism/v2-feedback/issues/27.

## Discussion
This only provides a client-side validation and is only applicable for browsers supporting HTML5.