### PR TITLE
Walkthrough integration

### DIFF
--- a/app/assets/stylesheets/walkthrough.scss
+++ b/app/assets/stylesheets/walkthrough.scss
@@ -1,0 +1,21 @@
+.walkthrough {
+  h1, h2, h3, h4, h5, h6 {
+    margin-bottom: 20px;
+    font-weight: bold;
+  }
+
+  blockquote {
+    padding: 10px;
+    margin-bottom: 20px;
+    border-left: 2px solid #eceeef;
+    margin-left: 0;
+  }
+
+  img {
+    width: 100%;
+  }
+
+  hr {
+    margin-bottom: 20px;
+  }
+}

--- a/app/controllers/my/solutions_controller.rb
+++ b/app/controllers/my/solutions_controller.rb
@@ -31,7 +31,7 @@ class My::SolutionsController < MyController
   end
 
   def walkthrough
-    @walkthrough_json = Git::WebsiteContent.head.walkthrough['walkthrough.json']
+    @walkthrough = Git::WebsiteContent.head.walkthrough['compiled.html']
     render_modal("solution-walkthrough", "walkthrough")
   end
 

--- a/app/views/my/solutions/walkthrough.html.haml
+++ b/app/views/my/solutions/walkthrough.html.haml
@@ -1,7 +1,5 @@
 #modal-close-button x
 .header
-.content
+.content.walkthrough
+  = @walkthrough.html_safe
 .buttons
-
-:javascript
-  setupWalkthrough(#{raw @walkthrough_json}, "#{current_user.auth_token}", "#{@solution.exercise.download_command}")


### PR DESCRIPTION
This renders the compiled walkthrough HTML outlined in https://github.com/exercism/interactive-cli-walkthrough/pull/2 into the walkthrough modal.

## Brief summary
1. `interactive-cli-walkthrough` contains our walkthrough which is broken down into several markdown files. These markdown files are compiled into one HTML output. For more information, please view https://github.com/exercism/interactive-cli-walkthrough/pull/2.
2. In order for changes to `interactive-cli-walkthrough` to be picked up, it lives as a `git subtree` within `website-copy`.
3. When the `website-copy` repo is fetched by `prototype`, it implies that changes to `interactive-cli-walktrhough` will be picked up as well.
4. `prototype` renders the compiled HTML into the walkthrough modal. In order for it to look better, CSS was added.

## Screencast
https://streamable.com/bgw83

