### PR TITLE
Add filters to mentor dashboard

### DIFF
--- a/app/assets/javascripts/options.js
+++ b/app/assets/javascripts/options.js
@@ -1,0 +1,4 @@
+window.updateOptions = function(select, options) {
+  select.clearOptions();
+  select.addOption(options);
+}

--- a/app/assets/stylesheets/pages/mentor-dashboard.scss
+++ b/app/assets/stylesheets/pages/mentor-dashboard.scss
@@ -40,7 +40,6 @@
         margin-bottom:40px;
     }
     .widget-filter {
-        float:right;
         margin-right:0;
         .selectize-control {
             width:220px;

--- a/app/controllers/mentor/dashboard_controller.rb
+++ b/app/controllers/mentor/dashboard_controller.rb
@@ -1,7 +1,23 @@
 class Mentor::DashboardController < MentorController
   def show
     @status = params[:status]
-    @your_solutions = RetrievesSolutionsForMentor.retrieve(current_user, @status)
+    @status_options = {
+      "Requires action from you": :require_action,
+      "Waiting for them": :awaiting_user,
+      "Completed": :completed,
+      "Stale": :stale,
+      "Unsubscribed": :abandoned
+    }
+    @track_id = params[:track_id]
+    @track_id_options = current_user.
+      mentored_tracks.
+      map { |track| [track.title, track.id] }
+
+    @your_solutions = RetrievesSolutionsForMentor.retrieve(
+      current_user,
+      status: @status,
+      track_id: @track_id
+    )
     @suggested_solutions = SelectsSuggestedSolutionsForMentor.select(current_user, params[:page])
 
     user_ids = @your_solutions.pluck(:user_id) + @suggested_solutions.pluck(:user_id)

--- a/app/controllers/mentor/dashboard_controller.rb
+++ b/app/controllers/mentor/dashboard_controller.rb
@@ -12,11 +12,23 @@ class Mentor::DashboardController < MentorController
     @track_id_options = current_user.
       mentored_tracks.
       map { |track| [track.title, track.id] }
+    @exercise_id = params[:exercise_id]
+    @track = Track.find_by(id: @track_id)
+    @exercise_id_options = if @track
+                             @track.
+                               exercises.
+                               map do |exercise|
+                                 { text: exercise.title, value: exercise.id }
+                               end
+                           else
+                             []
+                           end
 
     @your_solutions = RetrievesSolutionsForMentor.retrieve(
       current_user,
       status: @status,
-      track_id: @track_id
+      track_id: @track_id,
+      exercise_id: @exercise_id
     )
     @suggested_solutions = SelectsSuggestedSolutionsForMentor.select(current_user, params[:page])
 

--- a/app/controllers/mentor/dashboard_controller.rb
+++ b/app/controllers/mentor/dashboard_controller.rb
@@ -1,7 +1,7 @@
 class Mentor::DashboardController < MentorController
   def show
-    @filter = params[:filter].try(:to_sym)
-    @your_solutions = RetrieveSolutionsForMentor.retrieve(current_user, @filter)
+    @status = params[:status]
+    @your_solutions = RetrievesSolutionsForMentor.retrieve(current_user, @status)
     @suggested_solutions = SelectsSuggestedSolutionsForMentor.select(current_user, params[:page])
 
     user_ids = @your_solutions.pluck(:user_id) + @suggested_solutions.pluck(:user_id)

--- a/app/controllers/mentor/dashboard_controller.rb
+++ b/app/controllers/mentor/dashboard_controller.rb
@@ -1,13 +1,7 @@
 class Mentor::DashboardController < MentorController
   def show
     @status = params[:status]
-    @status_options = {
-      "Requires action from you": :require_action,
-      "Waiting for them": :awaiting_user,
-      "Completed": :completed,
-      "Stale": :stale,
-      "Unsubscribed": :abandoned
-    }
+    @status_options = SolutionMentorship::STATUSES
     @track_id = params[:track_id]
     @track_id_options = current_user.
       mentored_tracks.

--- a/app/controllers/mentor/dashboard_controller.rb
+++ b/app/controllers/mentor/dashboard_controller.rb
@@ -2,21 +2,14 @@ class Mentor::DashboardController < MentorController
   def show
     @status = params[:status]
     @status_options = SolutionMentorship::STATUSES
+
     @track_id = params[:track_id]
-    @track_id_options = current_user.
-      mentored_tracks.
-      map { |track| [track.title, track.id] }
+    @track_id_options = OptionsHelper.as_options(current_user.mentored_tracks,
+                                                 :title,
+                                                 :id)
+
     @exercise_id = params[:exercise_id]
-    @track = Track.find_by(id: @track_id)
-    @exercise_id_options = if @track
-                             @track.
-                               exercises.
-                               map do |exercise|
-                                 { text: exercise.title, value: exercise.id }
-                               end
-                           else
-                             []
-                           end
+    @exercise_id_options = exercise_id_options
 
     @your_solutions = RetrievesSolutionsForMentor.retrieve(
       current_user,
@@ -33,6 +26,15 @@ class Mentor::DashboardController < MentorController
     @total_solutions_count = current_user.mentored_solutions.count
     @total_students_count = current_user.mentored_solutions.select(:user_id).distinct.count
     @feedbacks = current_user.solution_mentorships.where(show_feedback_to_mentor: true).order('updated_at desc').limit(5).pluck(:feedback)
+  end
+
+  private
+
+  def exercise_id_options
+    track = Track.find_by(id: @track_id)
+    return [] unless track
+
+    OptionsHelper.as_options(track.exercises, :title, :id)
   end
 end
 

--- a/app/helpers/options_helper.rb
+++ b/app/helpers/options_helper.rb
@@ -1,0 +1,18 @@
+module OptionsHelper
+  def as_options(collection, title_field, value_field)
+    collection.map do |record|
+      { text: record.send(title_field), value: record.send(value_field) }
+    end
+  end
+
+  def format_options(options)
+    options.each_with_object({}) do |option, hash|
+      value = option[:value]
+      text = option[:text]
+
+      hash[text] = value
+    end
+  end
+
+  extend self
+end

--- a/app/models/solution_mentorship.rb
+++ b/app/models/solution_mentorship.rb
@@ -1,4 +1,12 @@
 class SolutionMentorship < ApplicationRecord
+  STATUSES = [
+    { text: "Requires action from you", value: :require_action },
+    { text: "Waiting for them", value: :awaiting_user },
+    { text: "Completed", value: :completed },
+    { text: "Stale", value: :stale },
+    { text: "Unsubscribed", value: :unsubscribed },
+  ]
+
   belongs_to :user
   belongs_to :solution
 end

--- a/app/services/filters_solutions_by_status.rb
+++ b/app/services/filters_solutions_by_status.rb
@@ -1,55 +1,55 @@
-class RetrieveSolutionsForMentor
-  def self.retrieve(*args)
-    new(*args).retrieve
+class FiltersSolutionsByStatus
+  def self.filter(*args)
+    new(*args).filter
   end
 
-  attr_reader :user, :filter
-  def initialize(user, filter)
-    @user = user
-    @filter = filter
+  attr_reader :solutions, :status
+
+  def initialize(solutions, status)
+    @solutions = solutions
+    @status = status
   end
 
-  def retrieve
-    solutions = if filter.present? && respond_to?("retrieve_#{filter}")
-        send("retrieve_#{filter}")
+  def filter
+    @solutions = if status.present? && respond_to?("filter_#{status}")
+        send("filter_#{status}")
       else
-        retrieve_require_action
+        filter_require_action
       end
     solutions.includes(iterations: [], exercise: {track: []}, user: [:profile]).
               limit(20) # TODO - Paginate
   end
 
-  def retrieve_require_action
-    user.mentored_solutions.
+  def filter_require_action
+    solutions.
       where("solution_mentorships.abandoned": false).
       where("solution_mentorships.requires_action": true)
   end
 
-  def retrieve_completed
-    user.mentored_solutions.
+  def filter_completed
+    solutions.
       where("solution_mentorships.abandoned": false).
       completed.
       where("solution_mentorships.requires_action": false)
   end
 
-  def retrieve_awaiting_user
-    user.mentored_solutions.
+  def filter_awaiting_user
+    solutions.
       where("solution_mentorships.abandoned": false).
       not_completed.
       where("solution_mentorships.requires_action": false).
       where("last_updated_by_user_at > ?", DateTime.now - 7.days)
   end
 
-  def retrieve_stale
-    user.mentored_solutions.
+  def filter_stale
+    solutions.
       where("solution_mentorships.abandoned": false).
       not_completed.
       where("solution_mentorships.requires_action": false).
       where("last_updated_by_user_at <= ?", DateTime.now - 7.days)
   end
 
-  def retrieve_abandoned
-    user.mentored_solutions.
-      where("solution_mentorships.abandoned": true)
+  def filter_abandoned
+    solutions.where("solution_mentorships.abandoned": true)
   end
 end

--- a/app/services/retrieves_solutions_for_mentor.rb
+++ b/app/services/retrieves_solutions_for_mentor.rb
@@ -3,21 +3,23 @@ class RetrievesSolutionsForMentor
     new(*args).retrieve
   end
 
-  def initialize(mentor, status: nil, track_id: nil)
+  def initialize(mentor, status: nil, track_id: nil, exercise_id: nil)
     @solutions = mentor.mentored_solutions
     @status = status
     @track_id = track_id
+    @exercise_id = exercise_id
   end
 
   def retrieve
     filter_by_status! if status.present?
     filter_by_track! if track_id.present?
+    filter_by_exercise! if exercise_id.present?
 
     solutions
   end
 
   private
-  attr_reader :solutions, :status, :track_id
+  attr_reader :solutions, :status, :track_id, :exercise_id
 
   def filter_by_status!
     @solutions = FiltersSolutionsByStatus.filter(solutions, status)
@@ -27,5 +29,11 @@ class RetrievesSolutionsForMentor
     @solutions = @solutions.
       joins(:exercise).
       where(exercises: { track_id: track_id })
+  end
+
+  def filter_by_exercise!
+    @solutions = @solutions.
+      joins(:exercise).
+      where(exercises: { id: exercise_id })
   end
 end

--- a/app/services/retrieves_solutions_for_mentor.rb
+++ b/app/services/retrieves_solutions_for_mentor.rb
@@ -20,5 +20,4 @@ class RetrievesSolutionsForMentor
   def filter_by_status!
     @solutions = FiltersSolutionsByStatus.filter(solutions, filter)
   end
-
 end

--- a/app/services/retrieves_solutions_for_mentor.rb
+++ b/app/services/retrieves_solutions_for_mentor.rb
@@ -1,0 +1,24 @@
+class RetrievesSolutionsForMentor
+  def self.retrieve(*args)
+    new(*args).retrieve
+  end
+
+  def initialize(mentor, filter)
+    @solutions = mentor.mentored_solutions
+    @filter = filter
+  end
+
+  def retrieve
+    filter_by_status! if filter
+
+    solutions
+  end
+
+  private
+  attr_reader :solutions, :filter
+
+  def filter_by_status!
+    @solutions = FiltersSolutionsByStatus.filter(solutions, filter)
+  end
+
+end

--- a/app/services/retrieves_solutions_for_mentor.rb
+++ b/app/services/retrieves_solutions_for_mentor.rb
@@ -3,21 +3,29 @@ class RetrievesSolutionsForMentor
     new(*args).retrieve
   end
 
-  def initialize(mentor, filter)
+  def initialize(mentor, status: nil, track_id: nil)
     @solutions = mentor.mentored_solutions
-    @filter = filter
+    @status = status
+    @track_id = track_id
   end
 
   def retrieve
-    filter_by_status! if filter
+    filter_by_status! if status.present?
+    filter_by_track! if track_id.present?
 
     solutions
   end
 
   private
-  attr_reader :solutions, :filter
+  attr_reader :solutions, :status, :track_id
 
   def filter_by_status!
-    @solutions = FiltersSolutionsByStatus.filter(solutions, filter)
+    @solutions = FiltersSolutionsByStatus.filter(solutions, status)
+  end
+
+  def filter_by_track!
+    @solutions = @solutions.
+      joins(:exercise).
+      where(exercises: { track_id: track_id })
   end
 end

--- a/app/views/mentor/dashboard/_filters.html.haml
+++ b/app/views/mentor/dashboard/_filters.html.haml
@@ -1,9 +1,14 @@
 =form_tag mentor_dashboard_path, method: :get, remote: true do
   .widget-filter
     .title Status:
-    =select_tag :status, options_for_select(@status_options, @status)
+    =select_tag :status, options_for_select(status_options, status)
   .widget-filter
     .title Track:
     = select_tag :track_id,
-      options_for_select(@track_id_options, @track_id),
+      options_for_select(track_id_options, track_id),
+      include_blank: true
+  .widget-filter
+    .title Exercise:
+    = select_tag :exercise_id,
+      options_for_select(exercise_id_options, exercise_id),
       include_blank: true

--- a/app/views/mentor/dashboard/_filters.html.haml
+++ b/app/views/mentor/dashboard/_filters.html.haml
@@ -1,14 +1,15 @@
 =form_tag mentor_dashboard_path, method: :get, remote: true do
   .widget-filter
     .title Status:
-    =select_tag :status, options_for_select(status_options, status)
+    = select_tag :status,
+      options_for_select(OptionsHelper.format_options(status_options), status)
   .widget-filter
     .title Track:
     = select_tag :track_id,
-      options_for_select(track_id_options, track_id),
+      options_for_select(OptionsHelper.format_options(track_id_options), track_id),
       include_blank: true
   .widget-filter
     .title Exercise:
     = select_tag :exercise_id,
-      options_for_select(exercise_id_options, exercise_id),
+      options_for_select(OptionsHelper.format_options(exercise_id_options), exercise_id),
       include_blank: true

--- a/app/views/mentor/dashboard/_filters.html.haml
+++ b/app/views/mentor/dashboard/_filters.html.haml
@@ -1,0 +1,9 @@
+=form_tag mentor_dashboard_path, method: :get, remote: true do
+  .widget-filter
+    .title Status:
+    =select_tag :status, options_for_select(@status_options, @status)
+  .widget-filter
+    .title Track:
+    = select_tag :track_id,
+      options_for_select(@track_id_options, @track_id),
+      include_blank: true

--- a/app/views/mentor/dashboard/show.html.haml
+++ b/app/views/mentor/dashboard/show.html.haml
@@ -10,7 +10,7 @@
         =form_tag mentor_dashboard_path, method: :get, remote: true do
           .widget-filter
             .title Status:
-            =select_tag :filter, options_for_select({"Requires action from you": :require_action, "Waiting for them": :awaiting_user, "Completed": :completed, "Stale": :stale, "Unsubscribed": :abandoned}, @filter)
+            =select_tag :status, options_for_select({"Requires action from you": :require_action, "Waiting for them": :awaiting_user, "Completed": :completed, "Stale": :stale, "Unsubscribed": :abandoned}, @filter)
 
         %h2 Solutions you're mentoring
         .your-solutions{style: @your_solutions.present?? "display:block" : "display:none"}

--- a/app/views/mentor/dashboard/show.html.haml
+++ b/app/views/mentor/dashboard/show.html.haml
@@ -7,12 +7,12 @@
   .lo-container
     .pure-g
       .pure-u-2-3
-        =form_tag mentor_dashboard_path, method: :get, remote: true do
-          .widget-filter
-            .title Status:
-            =select_tag :status, options_for_select({"Requires action from you": :require_action, "Waiting for them": :awaiting_user, "Completed": :completed, "Stale": :stale, "Unsubscribed": :abandoned}, @filter)
-
         %h2 Solutions you're mentoring
+        = render "filters",
+          status: @status,
+          status_options: @status_options,
+          track_id: @track_id,
+          track_id_options: @track_id_options
         .your-solutions{style: @your_solutions.present?? "display:block" : "display:none"}
           = render "your_solutions", your_solutions: @your_solutions, user_tracks: @user_tracks
         .no-solutions.personal{style: @your_solutions.empty?? "display:block" : "display:none"}

--- a/app/views/mentor/dashboard/show.html.haml
+++ b/app/views/mentor/dashboard/show.html.haml
@@ -12,7 +12,9 @@
           status: @status,
           status_options: @status_options,
           track_id: @track_id,
-          track_id_options: @track_id_options
+          track_id_options: @track_id_options,
+          exercise_id: @exercise_id,
+          exercise_id_options: @exercise_id_options
         .your-solutions{style: @your_solutions.present?? "display:block" : "display:none"}
           = render "your_solutions", your_solutions: @your_solutions, user_tracks: @user_tracks
         .no-solutions.personal{style: @your_solutions.empty?? "display:block" : "display:none"}

--- a/app/views/mentor/dashboard/show.js.haml
+++ b/app/views/mentor/dashboard/show.js.haml
@@ -5,7 +5,6 @@
   $('.your-solutions').hide()
   $('.no-solutions.personal').show().html("You have no solutions in this category.")
 
-- if @track && @exercise_id.blank?
+- if @track_id && @exercise_id.blank?
   var select = $('#exercise_id')[0].selectize;
-  select.clearOptions();
-  select.addOption(#{@exercise_id_options.to_json.html_safe});
+  updateOptions(select, #{@exercise_id_options.to_json.html_safe});

--- a/app/views/mentor/dashboard/show.js.haml
+++ b/app/views/mentor/dashboard/show.js.haml
@@ -4,3 +4,8 @@
 -else
   $('.your-solutions').hide()
   $('.no-solutions.personal').show().html("You have no solutions in this category.")
+
+- if @track && @exercise_id.blank?
+  var select = $('#exercise_id')[0].selectize;
+  select.clearOptions();
+  select.addOption(#{@exercise_id_options.to_json.html_safe});

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,7 +1,9 @@
 require "test_helper"
+require "support/selectize_helpers"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include Devise::Test::IntegrationHelpers
+  include SelectizeHelpers
 
   driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
 

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,5 +1,15 @@
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+  include Devise::Test::IntegrationHelpers
+
   driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
+
+  protected
+
+  def sign_in!(user = nil)
+    @current_user = user || create(:user)
+    @current_user.confirm
+    sign_in @current_user
+  end
 end

--- a/test/helpers/options_helper_test.rb
+++ b/test/helpers/options_helper_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class OptionsHelperTest < ActiveSupport::TestCase
+  test "formats options for select" do
+    options = [
+      {
+        text: "Hello",
+        value: 1
+      },
+      {
+        text: "World",
+        value: 2
+      }
+    ]
+
+    expected = { "Hello" => 1, "World" => 2 }
+
+    assert_equal expected, OptionsHelper.format_options(options)
+  end
+
+  test "serializes a collection as options" do
+    Person = Struct.new(:id, :name)
+    user = Person.new(1, "User")
+    mentor = Person.new(2, "Mentor")
+    expected = [
+      { text: "User", value: 1 },
+      { text: "Mentor", value: 2 }
+    ]
+
+    assert_equal expected, OptionsHelper.as_options([user, mentor], :name, :id)
+  end
+end

--- a/test/services/filters_solutions_by_status_test.rb
+++ b/test/services/filters_solutions_by_status_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
-class RetrieveSolutionsForMentorTest < ActiveSupport::TestCase
-  test "retrieves solutions correctly" do
+class FiltersSolutionsByStatusTest < ActiveSupport::TestCase
+  test "filters solutions correctly" do
 
     never = create :solution
     awaiting_user = create :solution, last_updated_by_user_at: DateTime.now - 1.minute
@@ -36,11 +36,11 @@ class RetrieveSolutionsForMentorTest < ActiveSupport::TestCase
       create :solution_mentorship, solution: solution, user: user, abandoned: true, requires_action: true
     end
 
-    assert_equal [requires_action, requires_action_and_stale], RetrieveSolutionsForMentor.retrieve(user, :requires_action)
-    assert_equal [awaiting_user], RetrieveSolutionsForMentor.retrieve(user, :awaiting_user)
-    assert_equal [completed, completed_and_stale], RetrieveSolutionsForMentor.retrieve(user, :completed)
-    assert_equal [awaiting_user_and_stale], RetrieveSolutionsForMentor.retrieve(user, :stale)
-    assert_equal [abandoned_and_awaiting_user, abandoned_and_requires_action, abandoned_and_completed, abandoned_and_stale].sort, RetrieveSolutionsForMentor.retrieve(user, :abandoned).sort
+    assert_equal [requires_action, requires_action_and_stale], FiltersSolutionsByStatus.filter(user.mentored_solutions, :requires_action)
+    assert_equal [awaiting_user], FiltersSolutionsByStatus.filter(user.mentored_solutions, :awaiting_user)
+    assert_equal [completed, completed_and_stale], FiltersSolutionsByStatus.filter(user.mentored_solutions, :completed)
+    assert_equal [awaiting_user_and_stale], FiltersSolutionsByStatus.filter(user.mentored_solutions, :stale)
+    assert_equal [abandoned_and_awaiting_user, abandoned_and_requires_action, abandoned_and_completed, abandoned_and_stale].sort, FiltersSolutionsByStatus.filter(user.mentored_solutions, :abandoned).sort
   end
 end
 

--- a/test/services/retrieves_solutions_for_mentor_test.rb
+++ b/test/services/retrieves_solutions_for_mentor_test.rb
@@ -1,0 +1,67 @@
+require "test_helper"
+
+class RetrievesSolutionsForMentorTest < ActiveSupport::TestCase
+  test "returns mentored solutions" do
+    user = create(:user)
+    solution = create(:solution)
+    create(:solution_mentorship, user: user, solution: solution)
+
+    mentored_solutions = RetrievesSolutionsForMentor.retrieve(user)
+
+    assert_equal [solution], mentored_solutions
+  end
+
+  test "filters mentored solutions by status" do
+    user = create(:user)
+    solution = create(:solution, completed_at: Date.new(2016, 12, 25))
+    create(:solution_mentorship,
+           user: user,
+           solution: solution,
+           requires_action: false,
+           abandoned: false
+          )
+
+    completed_solutions = RetrievesSolutionsForMentor.retrieve(
+      user,
+      status: :completed
+    )
+    abandoned_solutions = RetrievesSolutionsForMentor.retrieve(
+      user,
+      status: :abandoned
+    )
+
+    assert_equal [solution], completed_solutions
+    assert_equal [], abandoned_solutions
+  end
+
+  test "filters mentored solutions by track" do
+    ruby = create(:track, title: "Ruby")
+    cpp = create(:track, title: "C++")
+    user = create(:user, mentored_tracks: [ruby, cpp])
+    hello_world_ruby = create(:exercise, track: ruby)
+    solution_ruby = create(:solution, exercise: hello_world_ruby)
+    hello_world_cpp = create(:exercise, track: cpp)
+    solution_cpp = create(:solution, exercise: hello_world_cpp)
+    create(:solution_mentorship,
+           user: user,
+           solution: solution_ruby,
+           requires_action: true)
+    create(:iteration, solution: solution_cpp)
+    create(:solution_mentorship,
+           user: user,
+           solution: solution_cpp,
+           requires_action: true)
+
+    cpp_solutions = RetrievesSolutionsForMentor.retrieve(
+      user,
+      track_id: cpp.id
+    )
+    ruby_solutions = RetrievesSolutionsForMentor.retrieve(
+      user,
+      track_id: ruby.id
+    )
+
+    assert_equal [solution_cpp], cpp_solutions
+    assert_equal [solution_ruby], ruby_solutions
+  end
+end

--- a/test/services/retrieves_solutions_for_mentor_test.rb
+++ b/test/services/retrieves_solutions_for_mentor_test.rb
@@ -46,7 +46,6 @@ class RetrievesSolutionsForMentorTest < ActiveSupport::TestCase
            user: user,
            solution: solution_ruby,
            requires_action: true)
-    create(:iteration, solution: solution_cpp)
     create(:solution_mentorship,
            user: user,
            solution: solution_cpp,
@@ -63,5 +62,36 @@ class RetrievesSolutionsForMentorTest < ActiveSupport::TestCase
 
     assert_equal [solution_cpp], cpp_solutions
     assert_equal [solution_ruby], ruby_solutions
+  end
+
+  test "filters mentored solutions by exercise" do
+    ruby = create(:track, title: "Ruby")
+    user = create(:user, mentored_tracks: [ruby])
+    hello_world = create(:exercise, title: "Hello World", track: ruby)
+    sorting = create(:exercise, title: "Sorting", track: ruby)
+    hello_world_solution = create(:solution, exercise: hello_world)
+    create(:solution_mentorship,
+           user: user,
+           solution: hello_world_solution,
+           requires_action: true)
+    sorting_solution = create(:solution, exercise: sorting)
+    create(:solution_mentorship,
+           user: user,
+           solution: sorting_solution,
+           requires_action: true)
+
+    hello_world_solutions = RetrievesSolutionsForMentor.retrieve(
+      user,
+      track_id: ruby.id,
+      exercise_id: hello_world.id
+    )
+    sorting_solutions = RetrievesSolutionsForMentor.retrieve(
+      user,
+      track_id: ruby.id,
+      exercise_id: sorting.id
+    )
+
+    assert_equal [hello_world_solution], hello_world_solutions
+    assert_equal [sorting_solution], sorting_solutions
   end
 end

--- a/test/support/selectize_helpers.rb
+++ b/test/support/selectize_helpers.rb
@@ -1,0 +1,8 @@
+module SelectizeHelpers
+  def select_option(option, id:)
+    within("select##{id}+.selectize-control") do
+      first('div.selectize-input').click
+      find('div.option', :text => option).click
+    end
+  end
+end

--- a/test/system/filter_solutions_test.rb
+++ b/test/system/filter_solutions_test.rb
@@ -48,4 +48,31 @@ class FilterSolutionsTest < ApplicationSystemTestCase
     assert page.has_link?(href: mentor_solution_path(solution_ruby))
     assert page.has_no_link?(href: mentor_solution_path(solution_cpp))
   end
+
+  test "filters solutions by exercise" do
+    ruby = create(:track, title: "Ruby")
+    mentor = create(:user, mentored_tracks: [ruby])
+    hello_world = create(:exercise, title: "Hello World", track: ruby)
+    sorting = create(:exercise, title: "Sorting", track: ruby)
+    hello_world_solution = create(:solution, exercise: hello_world)
+    create(:iteration, solution: hello_world_solution)
+    create(:solution_mentorship,
+           user: mentor,
+           solution: hello_world_solution,
+           requires_action: true)
+    sorting_solution = create(:solution, exercise: sorting)
+    create(:iteration, solution: sorting_solution)
+    create(:solution_mentorship,
+           user: mentor,
+           solution: sorting_solution,
+           requires_action: true)
+
+    sign_in!(mentor)
+    visit mentor_dashboard_path
+    select_option "Ruby", id: :track_id
+    select_option "Sorting", id: :exercise_id
+
+    assert page.has_link?(href: mentor_solution_path(sorting_solution))
+    assert page.has_no_link?(href: mentor_solution_path(hello_world_solution))
+  end
 end

--- a/test/system/filter_solutions_test.rb
+++ b/test/system/filter_solutions_test.rb
@@ -1,0 +1,24 @@
+require 'application_system_test_case'
+
+class FilterSolutionsTest < ApplicationSystemTestCase
+  test "filters solutions by status" do
+    track = create(:track)
+    mentor = create(:user, mentored_tracks: [track])
+    hello_world = create(:exercise, track: track)
+    solution = create(:solution,
+                      exercise: hello_world,
+                      completed_at: Date.new(2016, 12, 25))
+    create(:iteration, solution: solution)
+    create(:solution_mentorship,
+           user: mentor,
+           solution: solution,
+           abandoned: false,
+           requires_action: false)
+
+    sign_in!(mentor)
+    visit mentor_dashboard_path
+    select_option "Completed", id: :filter
+
+    assert page.has_link?(href: mentor_solution_path(solution))
+  end
+end

--- a/test/system/filter_solutions_test.rb
+++ b/test/system/filter_solutions_test.rb
@@ -21,4 +21,31 @@ class FilterSolutionsTest < ApplicationSystemTestCase
 
     assert page.has_link?(href: mentor_solution_path(solution))
   end
+
+  test "filters solutions by track" do
+    ruby = create(:track, title: "Ruby")
+    cpp = create(:track, title: "C++")
+    mentor = create(:user, mentored_tracks: [ruby, cpp])
+    hello_world_ruby = create(:exercise, track: ruby)
+    solution_ruby = create(:solution, exercise: hello_world_ruby)
+    hello_world_cpp = create(:exercise, track: cpp)
+    solution_cpp = create(:solution, exercise: hello_world_cpp)
+    create(:iteration, solution: solution_ruby)
+    create(:solution_mentorship,
+           user: mentor,
+           solution: solution_ruby,
+           requires_action: true)
+    create(:iteration, solution: solution_cpp)
+    create(:solution_mentorship,
+           user: mentor,
+           solution: solution_cpp,
+           requires_action: true)
+
+    sign_in!(mentor)
+    visit mentor_dashboard_path
+    select_option "Ruby", id: :track_id
+
+    assert page.has_link?(href: mentor_solution_path(solution_ruby))
+    assert page.has_no_link?(href: mentor_solution_path(solution_cpp))
+  end
 end

--- a/test/system/filter_solutions_test.rb
+++ b/test/system/filter_solutions_test.rb
@@ -17,7 +17,7 @@ class FilterSolutionsTest < ApplicationSystemTestCase
 
     sign_in!(mentor)
     visit mentor_dashboard_path
-    select_option "Completed", id: :filter
+    select_option "Completed", id: :status
 
     assert page.has_link?(href: mentor_solution_path(solution))
   end


### PR DESCRIPTION
To close https://github.com/exercism/reboot/issues/138, this PR adds Track and Exercise filters to the mentor dashboard.

## Solution
1. In order to allow for more filters to be added, refactor and rename `RetrievesSolutionsForMentor` to `FilterSolutionsByStatus`.
2. Add `RetrievesSolutionsForMentor` to accept additional options to filter by status, track_id, and exercise_id.
3. When a track is chosen from the filter, fetch the exercises associated from the track.
4. Run a JS script to update the options of the exercise select box based on the fetched exercises.

## Screencast
![sep-22-2017 15-13-11](https://user-images.githubusercontent.com/1901520/30733282-e0347e40-9fa8-11e7-900b-f61948681796.gif)


## Discussion
1. In order to preserve the old behavior, I decided to write a system test in order to be confident that I don't break anything.
2. Since we are using a JS based select plugin, I needed to write `SelectizeHelpers` in order to do actions on the select box.
3. `OptionsHelper` was added in order to add convenience method to serialize collections into a format understandable by the `Selectize` plugin, as well as Rails' `option_for_select`.