### PR TITLE
Use different alumnus strings

### DIFF
--- a/app/assets/stylesheets/widgets/maintainer.scss
+++ b/app/assets/stylesheets/widgets/maintainer.scss
@@ -40,22 +40,19 @@
         @include font-size(14, 17);
         letter-spacing:-0.3px;
     }
-    &.alumnus {
-        &:before {
-            content: "Alumnus";
-            position:absolute;
-            width:140px;
-            height:20px;
-            position:absolute;
-            left:-45px;
-            top:15px;
-            background:$color-2;
-            font-weight:$regular;
-            text-align:center;
-            color:#fff;
-            transform: rotate(-45deg);
-            @include font-size(12, 20);
-            z-index:5;
-        }
-    }
+  .banner {
+    position:absolute;
+    width:140px;
+    height:20px;
+    position:absolute;
+    left:-45px;
+    top:15px;
+    background:$color-2;
+    font-weight:$regular;
+    text-align:center;
+    color:#fff;
+    transform: rotate(-45deg);
+    @include font-size(12, 20);
+    z-index:5;
+  }
 }

--- a/app/assets/stylesheets/widgets/maintainer.scss
+++ b/app/assets/stylesheets/widgets/maintainer.scss
@@ -40,9 +40,9 @@
         @include font-size(14, 17);
         letter-spacing:-0.3px;
     }
-    &.allumnus {
+    &.alumnus {
         &:before {
-            content: "Allumnus";
+            content: "Alumnus";
             position:absolute;
             width:140px;
             height:20px;

--- a/app/controllers/my/tracks_controller.rb
+++ b/app/controllers/my/tracks_controller.rb
@@ -67,7 +67,7 @@ class My::TracksController < MyController
   def show_not_joined
     @track = Track.find(params[:id])
     @mentors = @track.mentorships.reorder('rand()')
-    @maintainers = @track.maintainers.visible.reorder('active DESC, rand()')
+    @maintainers = @track.maintainers.visible.reorder('alumnus DESC, rand()')
     @exercises = @track.exercises.active.reorder('rand()').limit(6)
     @testimonial = @track.testimonials.order('rand()').first
     @testimonial = Testimonial.generic.order('rand()').first unless @testimonial

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -12,7 +12,7 @@ class TracksController < ApplicationController
     return redirect_to [:my, @track] if user_signed_in?
 
     @mentors = @track.mentorships.reorder('rand()')
-    @maintainers = @track.maintainers.visible.reorder('active DESC, rand()')
+    @active_maintainers = @track.maintainers.visible.active.order('alumnus DESC, rand()')
     @exercises = @track.exercises.active.reorder('rand()').limit(6)
     @testimonial = @track.testimonials.order('rand()').first
     @testimonial = Testimonial.generic.order('rand()').first unless @testimonial

--- a/app/models/maintainer.rb
+++ b/app/models/maintainer.rb
@@ -2,6 +2,6 @@ class Maintainer < ApplicationRecord
   belongs_to :track
   belongs_to :user, optional: true
 
-  scope :active, -> { where(active: true) }
+  scope :active, -> { where(alumnus: nil) }
   scope :visible, -> { where(visible: true) }
 end

--- a/app/models/maintainer.rb
+++ b/app/models/maintainer.rb
@@ -4,4 +4,8 @@ class Maintainer < ApplicationRecord
 
   scope :active, -> { where(alumnus: nil) }
   scope :visible, -> { where(visible: true) }
+
+  def active?
+    alumnus.blank?
+  end
 end

--- a/app/services/git/syncs_maintainers.rb
+++ b/app/services/git/syncs_maintainers.rb
@@ -1,4 +1,5 @@
 class Git::SyncsMaintainers
+  DEFAULT_ALUMNUS_STRING = "alumnus"
 
   def self.sync!(track, maintainer_config)
     new(track, maintainer_config).sync!
@@ -37,7 +38,9 @@ class Git::SyncsMaintainers
     return unless gh_user.present? && show_on_website.present?
     return unless show_on_website
 
-    alumnus = m.fetch(:alumnus, false) || false
+    alumnus = m[:alumnus]
+
+    alumnus = DEFAULT_ALUMNUS_STRING if alumnus == true
 
     gh_profile = Git::GithubProfile.for_user(gh_user)
 
@@ -45,7 +48,7 @@ class Git::SyncsMaintainers
     link_text = m.fetch(:link_text, link_url)
 
     maintainer_data = {
-      active: !alumnus,
+      alumnus: alumnus,
       name: (m[:name] || gh_profile.name),
       bio: (m[:bio] || gh_profile.bio),
       avatar_url: (m[:avatar_url] || gh_profile.avatar_url),

--- a/app/views/widgets/_banner.html.haml
+++ b/app/views/widgets/_banner.html.haml
@@ -1,0 +1,1 @@
+%span.banner= text

--- a/app/views/widgets/_maintainer.html.haml
+++ b/app/views/widgets/_maintainer.html.haml
@@ -1,4 +1,6 @@
-.widget-maintainer{class: maintainer.active ? "active" : "alumnus"}
+.widget-maintainer
+  - unless maintainer.active?
+    = render "widgets/banner", text: maintainer.alumnus.capitalize
   .pure-g
     .pure-u-1-4
       =image_tag maintainer.avatar_url

--- a/app/views/widgets/_maintainer.html.haml
+++ b/app/views/widgets/_maintainer.html.haml
@@ -1,4 +1,4 @@
-.widget-maintainer{class: maintainer.active ? "active" : "allumnus"}
+.widget-maintainer{class: maintainer.active ? "active" : "alumnus"}
   .pure-g
     .pure-u-1-4
       =image_tag maintainer.avatar_url

--- a/db/migrate/20170922081639_add_alumnus_to_maintainers.rb
+++ b/db/migrate/20170922081639_add_alumnus_to_maintainers.rb
@@ -1,0 +1,5 @@
+class AddAlumnusToMaintainers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :maintainers, :alumnus, :string
+  end
+end

--- a/db/migrate/20170922081759_populate_alummus_strings.rb
+++ b/db/migrate/20170922081759_populate_alummus_strings.rb
@@ -1,0 +1,11 @@
+class PopulateAlummusStrings < ActiveRecord::Migration[5.1]
+  def up
+    Maintainer.find_each do |maintainer|
+      maintainer.update(alumnus: "alumnus") unless maintainer.active?
+    end
+  end
+
+  def down
+    Maintainer.update_all(alumnus: nil)
+  end
+end

--- a/db/migrate/20170922082233_drop_column_active_from_maintainers.rb
+++ b/db/migrate/20170922082233_drop_column_active_from_maintainers.rb
@@ -1,0 +1,5 @@
+class DropColumnActiveFromMaintainers < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :maintainers, :active, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170922081759) do
+ActiveRecord::Schema.define(version: 20170922082233) do
 
   create_table "auth_tokens", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.bigint "user_id", null: false
@@ -134,7 +134,6 @@ ActiveRecord::Schema.define(version: 20170922081759) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "alumnus"
-    t.boolean "active", default: true, null: false
     t.index ["track_id"], name: "fk_rails_ed46fd11a4"
     t.index ["user_id"], name: "fk_rails_5b1168410c"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170922081639) do
+ActiveRecord::Schema.define(version: 20170922081759) do
 
   create_table "auth_tokens", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.bigint "user_id", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170825173701) do
+ActiveRecord::Schema.define(version: 20170922081639) do
 
   create_table "auth_tokens", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.bigint "user_id", null: false
@@ -130,10 +130,11 @@ ActiveRecord::Schema.define(version: 20170825173701) do
     t.string "link_text"
     t.string "link_url"
     t.text "bio"
-    t.boolean "active", default: true, null: false
     t.boolean "visible", default: true, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "alumnus"
+    t.boolean "active", default: true, null: false
     t.index ["track_id"], name: "fk_rails_ed46fd11a4"
     t.index ["user_id"], name: "fk_rails_5b1168410c"
   end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -33,7 +33,7 @@ FactoryGirl.define do
     track { create :track }
     github_username "iHiD"
     name "Jeremy Walker"
-    avatar_url "somewhere.jpg"
+    avatar_url "http://website.com/somewhere.jpg"
   end
 
   factory :exercise_topic do

--- a/test/models/maintainer_test.rb
+++ b/test/models/maintainer_test.rb
@@ -7,4 +7,16 @@ class MaintainerTest < ActiveSupport::TestCase
 
     assert_equal 6, Maintainer.active.count
   end
+
+  test "active when no alumnus string" do
+    maintainer = build(:maintainer, alumnus: nil)
+
+    assert maintainer.active?
+  end
+
+  test "not active when alumnus string exists" do
+    maintainer = build(:maintainer, alumnus: "alumnus")
+
+    refute maintainer.active?
+  end
 end

--- a/test/models/maintainer_test.rb
+++ b/test/models/maintainer_test.rb
@@ -1,7 +1,10 @@
 require 'test_helper'
 
 class MaintainerTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "returns active maintainers" do
+    create_list(:maintainer, 5, alumnus: "alumnus")
+    create_list(:maintainer, 6, alumnus: nil)
+
+    assert_equal 6, Maintainer.active.count
+  end
 end

--- a/test/services/git/syncs_maintainers_test.rb
+++ b/test/services/git/syncs_maintainers_test.rb
@@ -55,6 +55,24 @@ class Git::SyncsMaintainersTest < ActiveSupport::TestCase
     assert_empty @track.maintainers
   end
 
+  test "alumnus field defaults to 'alumnus' if true" do
+    maintainers_config = {
+      maintainers: [
+        {
+          github_username: "jo1",
+          show_on_website: true,
+          name: "Joanne Bloggs",
+          alumnus: true
+        }
+      ]
+    }
+    Git::SyncsMaintainers.sync!(@track, maintainers_config)
+
+    assert_equal 1, @track.maintainers.size
+    assert_equal false, @track.maintainers.first.active?
+    assert_equal "alumnus", @track.maintainers.first.alumnus
+  end
+
   test "drops maintainers with no gh_user or show_on_website" do
     maintainers_config = {
       maintainers: [
@@ -190,39 +208,6 @@ class Git::SyncsMaintainersTest < ActiveSupport::TestCase
     Git::SyncsMaintainers.sync!(@track, maintainers_config)
 
     assert_empty @track.maintainers
-  end
-
-  test "alumnus field populates active property, and defaults to false if absent" do
-    maintainers_config = {
-      maintainers: [
-        {
-          github_username: "jo1",
-          show_on_website: true,
-          name: "Joanne Bloggs",
-          alumnus: true
-        }
-      ]
-    }
-    Git::SyncsMaintainers.sync!(@track, maintainers_config)
-
-    assert_equal 1, @track.maintainers.size
-    assert_equal false, @track.maintainers.first.active?
-  end
-
-  test "alumnus field defaults to false (active=true) if absent" do
-    maintainers_config = {
-      maintainers: [
-        {
-          github_username: "jo1",
-          show_on_website: true,
-          name: "Joanne Bloggs"
-        }
-      ]
-    }
-    Git::SyncsMaintainers.sync!(@track, maintainers_config)
-
-    assert_equal 1, @track.maintainers.size
-    assert_equal true, @track.maintainers.first.active?
   end
 
   test "avatar_url defaults to your GitHub avatar if null or absent" do

--- a/test/system/track_alumnus_test.rb
+++ b/test/system/track_alumnus_test.rb
@@ -1,0 +1,12 @@
+require "application_system_test_case"
+
+class TrackAlumnusTest < ApplicationSystemTestCase
+  test "shows track alumnus banner" do
+    track = create(:track)
+    alumnus = create(:maintainer, track: track, alumnus: "alumnum")
+
+    visit team_page_path
+
+    assert page.has_content?("Alumnum")
+  end
+end

--- a/test/views/maintainer_widget_test.rb
+++ b/test/views/maintainer_widget_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class MaintainerWidgetTest < ActionView::TestCase
+  test "renders banner for an alumnus" do
+    maintainer = build(:maintainer, alumnus: "alumnum")
+
+    render "widgets/maintainer", maintainer: maintainer
+
+    assert_select ".banner", text: "Alumnum"
+  end
+
+  test "hides banner for an active maintainer" do
+    maintainer = build(:maintainer, alumnus: nil)
+
+    render "widgets/maintainer", maintainer: maintainer
+
+    assert_select ".banner", 0
+  end
+end


### PR DESCRIPTION
As outlined in https://github.com/exercism/reboot/issues/130, our `maintainers.json` file has been updated to support different strings in the `alumnus` attribute. This PR allows that change to reflect on the website.

## Solution
1. Instead of having an `active` column in the `maintainers` table, use an `alumnus` table instead. It can be inferred that when the `alumnus` column is empty, the maintainer is active.
2. Since we're dropping a column, add a migration to migrate data from the existing production site. All active maintainers has `alumnus=nil`, while alumni are assign `alumnus="alumnus"`.
3. Update `Maintainer.active` and `Maintainer#active?` to infer if a maintainer is active based on the `alumnus` column.
4. In the maintainer widget, render the banner only when the maintainer displayed is an alumnus. The banner text can be retrieved from the `alumnus` column. In order for the text can be put into the banner, the pseudo element was refactored into a span.
5. Update `Git::SyncsMaintainers` to save the `alumnus` field directly. We set the `alumnus` field to "alumnus` if `maintainers.json` has `{alumnus: true}`.
6. Update controllers to stop sorting by the `active` field, but sort by the `alumnus` field instead.

## Screenshots
<img width="540" alt="screen shot 2017-09-22 at 5 49 47 pm" src="https://user-images.githubusercontent.com/1901520/30739294-5eec8000-9fbf-11e7-9326-49db13ea014b.png">
