### PR TITLE
Hotfix: Fix alumnus = "0"

### DIFF
--- a/app/services/git/syncs_maintainers.rb
+++ b/app/services/git/syncs_maintainers.rb
@@ -38,9 +38,7 @@ class Git::SyncsMaintainers
     return unless gh_user.present? && show_on_website.present?
     return unless show_on_website
 
-    alumnus = m[:alumnus]
-
-    alumnus = DEFAULT_ALUMNUS_STRING if alumnus == true
+    alumnus = alumnus_string(m[:alumnus])
 
     gh_profile = Git::GithubProfile.for_user(gh_user)
 
@@ -65,6 +63,17 @@ class Git::SyncsMaintainers
 
   def remove_old_maintainers
     Maintainer.where(track: track).where.not(id: @maintainer_ids).delete_all
+  end
+
+  def alumnus_string(alumnus)
+    case alumnus
+    when true
+      DEFAULT_ALUMNUS_STRING
+    when false
+       nil
+    else
+      alumnus
+    end
   end
 
 end

--- a/db/migrate/20170923144117_fix_maintainers_with_alumnus_false.rb
+++ b/db/migrate/20170923144117_fix_maintainers_with_alumnus_false.rb
@@ -1,0 +1,9 @@
+class FixMaintainersWithAlumnusFalse < ActiveRecord::Migration[5.1]
+  def up
+    Maintainer.where(alumnus: "0").update_all(alumnus: nil)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170922082233) do
+ActiveRecord::Schema.define(version: 20170923144117) do
 
   create_table "auth_tokens", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.bigint "user_id", null: false

--- a/test/services/git/syncs_maintainers_test.rb
+++ b/test/services/git/syncs_maintainers_test.rb
@@ -73,6 +73,22 @@ class Git::SyncsMaintainersTest < ActiveSupport::TestCase
     assert_equal "alumnus", @track.maintainers.first.alumnus
   end
 
+  test "alumnus field defaults to nil if false" do
+    maintainers_config = {
+      maintainers: [
+        {
+          github_username: "jo1",
+          show_on_website: true,
+          name: "Joanne Bloggs",
+          alumnus: false
+        }
+      ]
+    }
+    Git::SyncsMaintainers.sync!(@track, maintainers_config)
+
+    assert_nil @track.maintainers.first.alumnus
+  end
+
   test "drops maintainers with no gh_user or show_on_website" do
     maintainers_config = {
       maintainers: [


### PR DESCRIPTION
After deploying the changes to the alumnus string, I noticed this on the website:

<img width="546" alt="screen shot 2017-09-23 at 10 42 54 pm" src="https://user-images.githubusercontent.com/1901520/30774162-af10c8ba-a0b0-11e7-83f4-3acba97cd551.png">

After looking into it further, I noticed that this particular maintainer had `{ alumnus: false }` in `maintainers.json`. That was a case I wasn't able to consider.

This PR fixes the following bug by:

1. Updating contributor syncing code to import maintainers with `{ alumnus: false }` in their `maintainers.json` as a `Maintainer` with `alumnus = nil`.
2. Adding a migration to update all `Maintainers` with `alumnus = "0"` to `alumnus = nil`.