### PR TITLE
Hotfix: Show solutions requiring action by default

### DIFF
--- a/app/services/retrieves_solutions_for_mentor.rb
+++ b/app/services/retrieves_solutions_for_mentor.rb
@@ -11,7 +11,7 @@ class RetrievesSolutionsForMentor
   end
 
   def retrieve
-    filter_by_status! if status.present?
+    filter_by_status!
     filter_by_track! if track_id.present?
     filter_by_exercise! if exercise_id.present?
 

--- a/test/services/retrieves_solutions_for_mentor_test.rb
+++ b/test/services/retrieves_solutions_for_mentor_test.rb
@@ -1,14 +1,15 @@
 require "test_helper"
 
 class RetrievesSolutionsForMentorTest < ActiveSupport::TestCase
-  test "returns mentored solutions" do
+  test "filters by status by default" do
     user = create(:user)
     solution = create(:solution)
-    create(:solution_mentorship, user: user, solution: solution)
+    create(:solution_mentorship,
+           user: user,
+           solution: solution)
+    FiltersSolutionsByStatus.expects(:filter).with([solution], nil)
 
-    mentored_solutions = RetrievesSolutionsForMentor.retrieve(user)
-
-    assert_equal [solution], mentored_solutions
+    RetrievesSolutionsForMentor.retrieve(user)
   end
 
   test "filters mentored solutions by status" do

--- a/test/system/filter_solutions_test.rb
+++ b/test/system/filter_solutions_test.rb
@@ -22,6 +22,35 @@ class FilterSolutionsTest < ApplicationSystemTestCase
     assert page.has_link?(href: mentor_solution_path(solution))
   end
 
+  test "displays solutions requiring action by default" do
+    track = create(:track)
+    mentor = create(:user, mentored_tracks: [track])
+    hello_world = create(:exercise, track: track)
+    action_required_solution = create(:solution,
+                                      exercise: hello_world)
+    completed_solution = create(:solution,
+                                exercise: hello_world,
+                                completed_at: Date.new(2016, 12, 25))
+    create(:iteration, solution: action_required_solution)
+    create(:iteration, solution: completed_solution)
+    create(:solution_mentorship,
+           user: mentor,
+           solution: action_required_solution,
+           abandoned: false,
+           requires_action: true)
+    create(:solution_mentorship,
+           user: mentor,
+           solution: completed_solution,
+           abandoned: false,
+           requires_action: false)
+
+    sign_in!(mentor)
+    visit mentor_dashboard_path
+
+    assert page.has_link?(href: mentor_solution_path(action_required_solution))
+    assert page.has_no_link?(href: mentor_solution_path(completed_solution))
+  end
+
   test "filters solutions by track" do
     ruby = create(:track, title: "Ruby")
     cpp = create(:track, title: "C++")


### PR DESCRIPTION
While testing out the solution filters on production, I noticed that all the mentored solutions appear when the page is loaded. This is a bug since we want to display only the solutions requiring action.