### PR TITLE
Implement webhook listener to track contributors

### DIFF
--- a/app/controllers/webhooks/contributors_controller.rb
+++ b/app/controllers/webhooks/contributors_controller.rb
@@ -1,0 +1,44 @@
+require_relative '../../../lib/open_source'
+
+class Webhooks::ContributorsController < WebhooksController
+  before_action :verify_github_webhook
+
+  def create
+    contribution = OpenSource::Contribution.new(request.request_parameters)
+
+    unless contribution.complete?
+      head :no_content and return
+    end
+
+    contributor = Contributor.with_contribution(contribution)
+
+    if contributor.save
+      head :no_content
+    else
+      message = "Failed to save event with X-GitHub-Delivery: %s" % github_delivery
+      render json: {error: message}, status: 500
+    end
+  end
+
+  private
+
+  def verify_github_webhook
+    payload = request.raw_post
+    signature = 'sha1=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), secret, payload)
+    if !Rack::Utils.secure_compare(signature, github_signature)
+      render json: {error: 'invalid signature - delivery: %s' % github_delivery}, status: 500
+    end
+  end
+
+  def secret
+    ENV['GITHUB_WEBHOOK_SECRET'] || 'hot fudge sundae' # default for test env
+  end
+
+  def github_signature
+    request.env['HTTP_X_HUB_SIGNATURE']
+  end
+
+  def github_delivery
+    request.headers['HTTP_X_GITHUB_DELIVERY']
+  end
+end

--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -1,3 +1,11 @@
 class Contributor < ApplicationRecord
   validates_presence_of :github_id, :github_username
+
+  def self.with_contribution(contribution)
+    contributor = find_or_initialize_by(github_id: contribution.github_id)
+    contributor.avatar_url = contribution.avatar_url
+    contributor.github_username = contribution.username
+    contributor.num_contributions += 1
+    contributor
+  end
 end

--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -1,2 +1,3 @@
 class Contributor < ApplicationRecord
+  validates_presence_of :github_id, :github_username
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ Rails.application.routes.draw do
 
   namespace :webhooks do
     resources :repo_updates, only: [:create]
+    resources :contributors, only: [:create]
   end
 
   devise_for :users, controllers: {

--- a/db/migrate/20170923230700_disallow_null_github_ids_for_contributors.rb
+++ b/db/migrate/20170923230700_disallow_null_github_ids_for_contributors.rb
@@ -1,0 +1,5 @@
+class DisallowNullGithubIdsForContributors < ActiveRecord::Migration[5.1]
+  def change
+    change_column_null(:contributors, :github_id, false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170923211552) do
+ActiveRecord::Schema.define(version: 20170923230700) do
 
   create_table "auth_tokens", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.bigint "user_id", null: false
@@ -38,7 +38,7 @@ ActiveRecord::Schema.define(version: 20170923211552) do
     t.boolean "is_core", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "github_id"
+    t.integer "github_id", null: false
     t.index ["is_maintainer", "is_core", "num_contributions"], name: "main_find_idx"
   end
 

--- a/lib/open_source.rb
+++ b/lib/open_source.rb
@@ -1,0 +1,4 @@
+module OpenSource
+end
+
+require_relative 'open_source/contribution'

--- a/lib/open_source/contribution.rb
+++ b/lib/open_source/contribution.rb
@@ -1,0 +1,40 @@
+require 'json'
+require 'forwardable'
+
+class OpenSource::Contribution
+  attr_reader :payload
+  def initialize(payload)
+    # Do an extra roundtrip via JSON so we don't have to deal with hashes.
+    @payload = JSON.parse(payload.to_json, object_class: OpenStruct)
+  end
+
+  def complete?
+    merged? && to_default_branch?
+  end
+
+  def merged?
+    payload.action == 'closed' && payload.pull_request.merged
+  end
+
+  def to_default_branch?
+    payload.pull_request.base.ref == payload.repository.default_branch
+  end
+
+  def username
+    user.login
+  end
+
+  def github_id
+    user.id
+  end
+
+  def avatar_url
+    user.avatar_url
+  end
+
+  private
+
+  def user
+    payload.pull_request.user
+  end
+end

--- a/test/controllers/webhooks/contributors_controller_test.rb
+++ b/test/controllers/webhooks/contributors_controller_test.rb
@@ -1,0 +1,59 @@
+require_relative '../../test_helper'
+
+class Webhooks::ContributorsControllerTest < ActionDispatch::IntegrationTest
+  test "does not save incomplete contributions" do
+    post webhooks_contributors_path, default_options(fixture('pull_request_event.closed'))
+
+    assert_equal 0, Contributor.count
+  end
+
+  test "saves a contribution" do
+    post webhooks_contributors_path, default_options(fixture('pull_request_event.merged.to_default_master'))
+
+    assert_equal 1, Contributor.count
+  end
+
+  test "provides a useful error message if record fails to save" do
+    payload = fixture('pull_request_event.merged.to_default_master')
+    payload['pull_request']['user']['login'] = nil
+    post webhooks_contributors_path, default_options(payload)
+
+    assert_equal 500, response.status
+    assert_match "abc-123", JSON.parse(response.body)['error']
+  end
+
+  test "it doesn't process a request with an invalid signature" do
+    payload = fixture('pull_request_event.merged.to_non_default_branch')
+
+    options = default_options(payload)
+    options[:headers]['X-Hub-Signature'] = 'ZOMG wrong signature'
+    post webhooks_contributors_path, options
+
+    assert_equal 500, response.status
+    assert_match "abc-123", JSON.parse(response.body)['error']
+    assert_match "invalid signature", JSON.parse(response.body)['error']
+  end
+
+  private
+
+  def default_options(payload)
+    {
+      headers: {
+        'X-GitHub-Delivery' => 'abc-123',
+        # Signature is pre-calculated to match the post body 'fake'.
+        # Under normal circumstances, the request.raw_post is the actual raw
+        # post body that was received.
+        'X-Hub-Signature' => 'sha1=cfbe1b6a0950b651e6f07e951476bb818051ae16',
+      },
+      env: {
+        'action_dispatch.request.request_parameters' => payload,
+        'action_dispatch.request.raw_post' => 'fake',
+      }
+    }
+  end
+
+  def fixture(name)
+    path = '../../../fixtures/contributions/%s.json' % name
+    JSON.parse(File.read(File.absolute_path(path, __FILE__)))
+  end
+end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -6,6 +6,7 @@ FactoryGirl.define do
 
   factory :contributor do
     github_username { SecureRandom.uuid }
+    sequence(:github_id)
     avatar_url "asd.jpg"
     num_contributions 20
   end

--- a/test/fixtures/contributions/pull_request_event.closed.json
+++ b/test/fixtures/contributions/pull_request_event.closed.json
@@ -1,0 +1,19 @@
+{
+  "action": "closed",
+  "pull_request": {
+    "user": {
+      "login": "alice",
+      "id": 1,
+      "avatar_url": "https://example.com/alice.png",
+      "type": "User"
+    },
+    "base": {
+      "ref": "master"
+    },
+    "merged": false
+  },
+  "repository": {
+    "private": false,
+    "default_branch": "master"
+  }
+}

--- a/test/fixtures/contributions/pull_request_event.merged.to_default_master.json
+++ b/test/fixtures/contributions/pull_request_event.merged.to_default_master.json
@@ -1,0 +1,19 @@
+{
+  "action": "closed",
+  "pull_request": {
+    "user": {
+      "login": "carlos",
+      "id": 3,
+      "avatar_url": "https://example.com/carlos.png",
+      "type": "User"
+    },
+    "base": {
+      "ref": "master"
+    },
+    "merged": true
+  },
+  "repository": {
+    "private": false,
+    "default_branch": "master"
+  }
+}

--- a/test/fixtures/contributions/pull_request_event.merged.to_non_default_branch.json
+++ b/test/fixtures/contributions/pull_request_event.merged.to_non_default_branch.json
@@ -1,0 +1,19 @@
+{
+  "action": "closed",
+  "pull_request": {
+    "user": {
+      "login": "bob",
+      "id": 2,
+      "avatar_url": "https://example.com/bob.png",
+      "type": "User"
+    },
+    "base": {
+      "ref": "contributing-guide"
+    },
+    "merged": true
+  },
+  "repository": {
+    "private": false,
+    "default_branch": "master"
+  }
+}

--- a/test/fixtures/contributions/pull_request_event.merged.to_non_default_master.json
+++ b/test/fixtures/contributions/pull_request_event.merged.to_non_default_master.json
@@ -1,0 +1,19 @@
+{
+  "action": "closed",
+  "pull_request": {
+    "user": {
+      "login": "freya",
+      "id": 6,
+      "avatar_url": "https://example.com/freya.png",
+      "type": "User"
+    },
+    "base": {
+      "ref": "master"
+    },
+    "merged": true
+  },
+  "repository": {
+    "private": false,
+    "default_branch": "production"
+  }
+}

--- a/test/fixtures/contributions/pull_request_event.merged.to_non_standard_default.json
+++ b/test/fixtures/contributions/pull_request_event.merged.to_non_standard_default.json
@@ -1,0 +1,19 @@
+{
+  "action": "closed",
+  "pull_request": {
+    "user": {
+      "login": "eu-jin",
+      "id": 5,
+      "avatar_url": "https://example.com/eu-jin.png",
+      "type": "User"
+    },
+    "base": {
+      "ref": "production"
+    },
+    "merged": true
+  },
+  "repository": {
+    "private": false,
+    "default_branch": "production"
+  }
+}

--- a/test/fixtures/contributions/pull_request_event.opened.json
+++ b/test/fixtures/contributions/pull_request_event.opened.json
@@ -1,0 +1,19 @@
+{
+  "action": "opened",
+  "pull_request": {
+    "user": {
+      "login": "darius",
+      "id": 4,
+      "avatar_url": "https://example.com/darius.png",
+      "type": "User"
+    },
+    "base": {
+      "ref": "master"
+    },
+    "merged": false
+  },
+  "repository": {
+    "private": false,
+    "default_branch": "master"
+  }
+}

--- a/test/lib/open_source/contribution_test.rb
+++ b/test/lib/open_source/contribution_test.rb
@@ -1,0 +1,46 @@
+require 'minitest/autorun'
+require_relative '../../../lib/open_source'
+
+class OpenSourceContributionTest < Minitest::Test
+  def test_pr_opened
+    contribution = OpenSource::Contribution.new(fixture('pull_request_event.opened'))
+    refute contribution.complete?
+  end
+
+  def test_pr_closed_without_merging
+    contribution = OpenSource::Contribution.new(fixture('pull_request_event.closed'))
+    refute contribution.complete?
+  end
+
+  def test_pr_merged_to_non_default_branch
+    contribution = OpenSource::Contribution.new(fixture('pull_request_event.merged.to_non_default_branch'))
+    refute contribution.complete?
+  end
+
+  def test_pr_merged_to_non_default_master
+    contribution = OpenSource::Contribution.new(fixture('pull_request_event.merged.to_non_default_master'))
+    refute contribution.complete?
+  end
+
+  def test_pr_merged_to_default_master
+    contribution = OpenSource::Contribution.new(fixture('pull_request_event.merged.to_default_master'))
+    assert contribution.complete?
+    assert_equal 'carlos', contribution.username
+    assert_equal 3, contribution.github_id
+    assert_equal 'https://example.com/carlos.png', contribution.avatar_url
+  end
+
+  def test_pr_merged_to_non_standard_default
+    contribution = OpenSource::Contribution.new(fixture('pull_request_event.merged.to_non_standard_default'))
+    assert contribution.complete?
+    assert_equal 'eu-jin', contribution.username
+    assert_equal 5, contribution.github_id
+    assert_equal 'https://example.com/eu-jin.png', contribution.avatar_url
+  end
+
+  private
+
+  def fixture(name)
+    JSON.parse(File.read(File.absolute_path('../../../fixtures/contributions/%s.json' % name, __FILE__)))
+  end
+end

--- a/test/models/contributor_test.rb
+++ b/test/models/contributor_test.rb
@@ -1,7 +1,21 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class ContributorTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  FakeContribution = Struct.new(:github_id, :username, :avatar_url)
+
+  test "a valid contributor" do
+    assert Contributor.new(github_id: 1, github_username: 'alice').valid?
+  end
+
+  test "invalid without username" do
+    refute Contributor.new(github_id: 1).valid?
+  end
+
+  test "invalid without github_id" do
+    refute Contributor.new(github_id: 1).valid?
+  end
+
+  test "contributors have 0 contributions by default" do
+    assert_equal 0, Contributor.new.num_contributions
+  end
 end

--- a/test/models/contributor_test.rb
+++ b/test/models/contributor_test.rb
@@ -18,4 +18,48 @@ class ContributorTest < ActiveSupport::TestCase
   test "contributors have 0 contributions by default" do
     assert_equal 0, Contributor.new.num_contributions
   end
+
+  test "add a contribution for a new contributor" do
+    contribution = FakeContribution.new(100, 'alice', 'alice.png')
+
+    contributor = Contributor.with_contribution(contribution)
+    assert_equal 100, contributor.github_id
+    assert_equal 'alice', contributor.github_username
+    assert_equal 'alice.png', contributor.avatar_url
+    assert_equal 1, contributor.num_contributions
+  end
+
+  test "add a contribution for an existing contributor" do
+    attributes = {
+      github_username: 'alice',
+      github_id: 100,
+      avatar_url: 'alice.png',
+      num_contributions: 1,
+    }
+    contributor = Contributor.create!(attributes)
+    contribution = FakeContribution.new(100, 'alice', 'alice.png')
+
+    contributor = Contributor.with_contribution(contribution)
+    assert_equal 100, contributor.github_id
+    assert_equal 'alice', contributor.github_username
+    assert_equal 'alice.png', contributor.avatar_url
+    assert_equal 2, contributor.num_contributions
+  end
+
+  test "add a contribution for an existing contributor with new user data" do
+    attributes = {
+      github_username: 'alice',
+      github_id: 100,
+      avatar_url: 'alice.png',
+      num_contributions: 1,
+    }
+    contributor = Contributor.create!(attributes)
+    contribution = FakeContribution.new(100, 'allison', 'allison.png')
+
+    contributor = Contributor.with_contribution(contribution)
+    assert_equal 100, contributor.github_id
+    assert_equal 'allison', contributor.github_username
+    assert_equal 'allison.png', contributor.avatar_url
+    assert_equal 2, contributor.num_contributions
+  end
 end

--- a/test/models/factories_test.rb
+++ b/test/models/factories_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class Factories < ActiveSupport::TestCase
   FactoryGirl.factories.map(&:name).each do |factory|


### PR DESCRIPTION
**NOTE - this relies on the migration in https://github.com/exercism/prototype/pull/31 to be merged, deployed, and run.** This PR is built on top of the migration in question, but if we deploy before migrating, then we risk getting some 500 errors.

### Background

In the footer of the site we show a count of contributors. We need this number to be incremented
when someone new contributes to a repository in the Exercism organization.

When we run the ETL for v2, we will need to run the existing contributor script _once_ to backfill existing data, and then we can rely on the webhook to keep us up-to-date.

### Implementation

I ran into some interesting snags in this one.

* `params` vs `request.request_parameters`
* passing an actual post body in a Rails controller test
* `request.request_parameters` vs `request.raw_post`

#### Params vs request parameters

The JSON POST body is available via params, however everything is stringified. If you passed `{"ok": true, "number": 1}`, then the params hash has `{"ok": "true", "number": "1"}`.

The fix is to access the JSON POST body via `request.request_parameters`, which retains the original types for the values.

#### Testing with a POST body

The entire internet says to pass `params`:

```
post webhooks_contributors_path, params: {"ok": true, "number": 1}
```

That's fine if you're ok with stringified JSON values. Not so great if we need the original.

I dug into the Rails source code and figured out that the POST body can be passed as a key within the environment: `action_dispatch.request.request_parameters`. This should be the hash version, not the JSON version.

But this brings me to the trickiest bit.

#### Request parameters vs raw post

We need to verify the signature of the request. That means that we need to combine the original JSON string with our webhook secret, and do some hashing, and then compare the result to the signature that we get in the header. Saying `request.request_parameters.to_json` doesn't cut it. There are small differences in formatting, so we end up with a different signature.

Back to digging in the source, it turns out the request provides access to the original POST body: `request.raw_post`. We can use this value to calculate the signature.