### PR TITLE
Include the test server identity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@
 
 /app/assets/images/tmp
 
-server_identity
+/server_identity

--- a/test/fixtures/server_identity
+++ b/test/fixtures/server_identity
@@ -1,0 +1,1 @@
+hostname


### PR DESCRIPTION
We only want to ignore the server_identity file for development use.

The tests should have a fixture by default, otherwise we make new developers jump through
unnecessary hoops to get the tests running.