### PR TITLE
[migrations] Update contributors table

### DIFF
--- a/db/migrate/20170923211039_set_default_num_contributions_on_contributors.rb
+++ b/db/migrate/20170923211039_set_default_num_contributions_on_contributors.rb
@@ -1,0 +1,5 @@
+class SetDefaultNumContributionsOnContributors < ActiveRecord::Migration[5.1]
+  def change
+    change_column_default :contributors, :num_contributions, 0
+  end
+end

--- a/db/migrate/20170923211552_add_github_id_to_contributors.rb
+++ b/db/migrate/20170923211552_add_github_id_to_contributors.rb
@@ -1,0 +1,5 @@
+class AddGithubIdToContributors < ActiveRecord::Migration[5.1]
+  def change
+    add_column :contributors, :github_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170923211039) do
+ActiveRecord::Schema.define(version: 20170923211552) do
 
   create_table "auth_tokens", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.bigint "user_id", null: false
@@ -38,6 +38,7 @@ ActiveRecord::Schema.define(version: 20170923211039) do
     t.boolean "is_core", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "github_id"
     t.index ["is_maintainer", "is_core", "num_contributions"], name: "main_find_idx"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170923144117) do
+ActiveRecord::Schema.define(version: 20170923211039) do
 
   create_table "auth_tokens", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.bigint "user_id", null: false
@@ -33,7 +33,7 @@ ActiveRecord::Schema.define(version: 20170923144117) do
   create_table "contributors", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.string "github_username", null: false
     t.string "avatar_url", null: false
-    t.integer "num_contributions", null: false
+    t.integer "num_contributions", default: 0, null: false
     t.boolean "is_maintainer", default: false, null: false
     t.boolean "is_core", default: false, null: false
     t.datetime "created_at", null: false


### PR DESCRIPTION
This has two changes:

* Add a default value of 0 to the `num_contributions` column so that we don't have to jump through hoops to deal with NULL values.
* Add a GitHub ID, so that we can use that as a source of truth, since people can (and do) change their GitHub username.

This is a prerequisite for pull request #28, and should be merged and deployed before #28 lands.