### PR TITLE
[migrations] Don't allow nulls in GitHub ID for contributors

### DIFF
--- a/db/migrate/20170923230700_disallow_null_github_ids_for_contributors.rb
+++ b/db/migrate/20170923230700_disallow_null_github_ids_for_contributors.rb
@@ -1,0 +1,5 @@
+class DisallowNullGithubIdsForContributors < ActiveRecord::Migration[5.1]
+  def change
+    change_column_null(:contributors, :github_id, false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170923211552) do
+ActiveRecord::Schema.define(version: 20170923230700) do
 
   create_table "auth_tokens", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.bigint "user_id", null: false
@@ -38,7 +38,7 @@ ActiveRecord::Schema.define(version: 20170923211552) do
     t.boolean "is_core", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "github_id"
+    t.integer "github_id", null: false
     t.index ["is_maintainer", "is_core", "num_contributions"], name: "main_find_idx"
   end
 

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -6,6 +6,7 @@ FactoryGirl.define do
 
   factory :contributor do
     github_username { SecureRandom.uuid }
+    sequence(:github_id)
     avatar_url "asd.jpg"
     num_contributions 20
   end

--- a/test/models/factories_test.rb
+++ b/test/models/factories_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class Factories < ActiveSupport::TestCase
   FactoryGirl.factories.map(&:name).each do |factory|


### PR DESCRIPTION
I missed a spot :/

This is for https://github.com/exercism/prototype/pull/28