### PR TITLE
Order solutions on profile page by number of reactions

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -27,7 +27,12 @@ class ProfilesController < ApplicationController
   end
 
   def setup_solutions
-    @solutions = @profile.user.solutions.published.includes(exercise: :track)
+    @solutions = @profile.
+      user.
+      solutions.
+      published.
+      reorder('solutions.num_reactions DESC').
+      includes(exercise: :track)
 
     @tracks_for_select = Track.where(id: @solutions.joins(:exercise).select(:track_id)).
       map{|l|[l.title, l.id]}.

--- a/test/system/profile_solutions_test.rb
+++ b/test/system/profile_solutions_test.rb
@@ -1,0 +1,32 @@
+require 'application_system_test_case'
+
+class ProfileSolutionsTest < ApplicationSystemTestCase
+  test "orders solutions by number of reactions" do
+    user = create(:user)
+    create(:profile, user: user)
+    solution1 = create(:solution,
+                       user: user,
+                       num_reactions: 1,
+                       exercise: create(:exercise, title: "Exercise 3"),
+                       published_at: Date.new(2016, 12, 25))
+    create_list(:reaction, 1, solution: solution1)
+    solution2 = create(:solution,
+                       user: user,
+                       num_reactions: 2,
+                       exercise: create(:exercise, title: "Exercise 2"),
+                       published_at: Date.new(2016, 12, 25))
+    create_list(:reaction, 2, solution: solution2)
+    solution3 = create(:solution,
+                        user: user,
+                        num_reactions: 3,
+                        exercise: create(:exercise, title: "Exercise 1"),
+                        published_at: Date.new(2016, 12, 25))
+    create_list(:reaction, 3, solution: solution3)
+
+    sign_in!(user)
+    visit profile_path(user.handle)
+
+    exercises = page.find_all(".solution .title").map(&:text)
+    assert_equal ["Exercise 1", "Exercise 2", "Exercise 3"], exercises
+  end
+end


### PR DESCRIPTION
## Description
This orders user's solutions on the profile page by the number of reactions. This was done in order to stay consistent with the ordering of the solutions in the Community Solutions page. This should close https://github.com/exercism/reboot/issues/111.

## Screenshots
<img width="1110" alt="screen shot 2017-11-07 at 7 04 02 pm" src="https://user-images.githubusercontent.com/1901520/32490553-81efdf5e-c3ee-11e7-8fa2-26633c599013.png">
