### PR TITLE
Add titles to external pages

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -15,7 +15,7 @@ class PagesController < ApplicationController
     define_method page do
       markdown = Git::WebsiteContent.head.pages["#{page}.md"] || ""
       @page = page
-      @title = title
+      @page_title = title
       @content = ParsesMarkdown.parse(markdown.to_s)
       render action: "generic"
     end
@@ -27,7 +27,7 @@ class PagesController < ApplicationController
   end
 
   def team
-    @title = "The Exercism Team"
+    @page_title = "The Exercism Team"
     @maintainers_last_updated_at = Maintainer.order('updated_at DESC').limit(1).pluck(:updated_at)[0].to_i
     @maintainers = Maintainer.visible.reorder('LENGTH(bio) DESC').to_a.
                    group_by(&:github_username).map {|_, ms|

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -27,6 +27,7 @@ class PagesController < ApplicationController
   end
 
   def team
+    @title = "The Exercism Team"
     @maintainers_last_updated_at = Maintainer.order('updated_at DESC').limit(1).pluck(:updated_at)[0].to_i
     @maintainers = Maintainer.visible.reorder('LENGTH(bio) DESC').to_a.
                    group_by(&:github_username).map {|_, ms|

--- a/app/helpers/metadata_helper.rb
+++ b/app/helpers/metadata_helper.rb
@@ -1,6 +1,6 @@
 module MetadataHelper
   def metadata_title
-    @metadata_title ||= metadata.try(:fetch, :title, nil) || "Exercism"
+    @metadata_title ||= format_title(metadata.try(:fetch, :title, nil))
   end
 
   def metadata_description
@@ -16,6 +16,13 @@ module MetadataHelper
   end
 
   private
+
+  def format_title(title)
+    return "Exercism" unless title
+
+    "#{title} | Exercism"
+  end
+
   def metadata
     @metadata ||=
       case namespace_name
@@ -27,19 +34,34 @@ module MetadataHelper
           case action_name
           when :index
           else
-            {
-              title: @title
-            }
+            { title: @title }
           end
         when "tracks"
           case action_name
+          when "index"
+            { title: "Language Tracks" }
           when "show"
             {
-              title: "#{@track.title} on Exercism",
+              title: "#{@track.title}",
               description: @track.introduction,
               image_url: @track.bordered_turquoise_icon_url
             }
           end
+        when "exercises"
+          case action_name
+          when "index"
+            { title: "Exercises on the #{@track.title} Track" }
+          when "show"
+            { title: @exercise.title }
+          end
+        when "registrations"
+          { title: "Sign up" }
+        when "sessions"
+          { title: "Sign in" }
+        when "passwords"
+          { title: "Reset your password" }
+        when "confirmations"
+          { title: "Resend confirmation email" }
         end
       end
   end

--- a/app/helpers/metadata_helper.rb
+++ b/app/helpers/metadata_helper.rb
@@ -34,7 +34,7 @@ module MetadataHelper
           case action_name
           when :index
           else
-            { title: @title }
+            { title: @page_title }
           end
         when "tracks"
           case action_name


### PR DESCRIPTION
As discussed in https://github.com/exercism/reboot/issues/109, this PR adds page titles to external pages for the purposes of SEO.

As I haven't had any experience with SEO yet, I decided to follow this [resource](https://moz.com/learn/seo/title-tag) to format our title tags properly.