### PR TITLE
Put solutions in standard mode first in mentorship queue

### DIFF
--- a/app/services/selects_suggested_solutions_for_mentor.rb
+++ b/app/services/selects_suggested_solutions_for_mentor.rb
@@ -16,6 +16,9 @@ class SelectsSuggestedSolutionsForMentor
       joins(:exercise).
       where("exercises.track_id": tracks).
 
+      joins(user: :user_tracks).
+      where("user_tracks.track_id = exercises.track_id").
+
       # Not things you already mentor
       where.not(id: user.mentored_solutions).
 
@@ -37,9 +40,10 @@ class SelectsSuggestedSolutionsForMentor
       # Not completed
       where(completed_at: nil).
 
-      # Order by number of mentors (least first),
+      # Order standard mode tracks first,
+      # then by number of mentors (least first),
       # then age (oldest first)
-      order("num_mentors ASC, last_updated_by_user_at ASC").
+      order("independent_mode DESC, num_mentors ASC, last_updated_by_user_at ASC").
 
       includes(iterations: [], exercise: {track: []}, user: [:profile]).
 

--- a/test/services/selects_suggested_solutions_for_mentor_test.rb
+++ b/test/services/selects_suggested_solutions_for_mentor_test.rb
@@ -2,115 +2,220 @@ require 'test_helper'
 
 class SelectsSuggestedSolutionsForMentorTest < ActiveSupport::TestCase
   test "selects only mentored tracks" do
-    user = create :user
+    mentor = create(:user)
     track1 = create :track
     track2 = create :track
     track3 = create :track
+    mentee = create_mentee([track1, track2, track3])
 
-    solution1 = create :solution, exercise: create(:exercise, track: track1)
-    solution2 = create :solution, exercise: create(:exercise, track: track2)
-    solution3 = create :solution, exercise: create(:exercise, track: track3)
+    solution1 = create(:solution,
+                       exercise: create(:exercise, track: track1),
+                       user: mentee)
+    solution2 = create(:solution,
+                       exercise: create(:exercise, track: track2),
+                       user: mentee)
+    solution3 = create(:solution,
+                       exercise: create(:exercise, track: track3),
+                       user: mentee)
     create :iteration, solution: solution1
     create :iteration, solution: solution2
     create :iteration, solution: solution3
 
-    create :track_mentorship, user: user, track: track1
-    create :track_mentorship, user: user, track: track2
+    create :track_mentorship, user: mentor, track: track1
+    create :track_mentorship, user: mentor, track: track2
 
-    assert_equal [solution1, solution2].sort, SelectsSuggestedSolutionsForMentor.select(user).sort
+    assert_equal [solution1, solution2].sort, SelectsSuggestedSolutionsForMentor.select(mentor).sort
   end
 
   test "does not select solutions you already mentor" do
-    user, track = create_user_and_track
+    mentor, track = create_mentor_and_track
+    mentee = create_mentee([track])
 
-    bad_solution = create :solution, exercise: create(:exercise, track: track)
-    good_solution = create :solution, exercise: create(:exercise, track: track)
+    bad_solution = create(:solution,
+                          exercise: create(:exercise, track: track),
+                          user: mentee)
+    good_solution = create(:solution,
+                           exercise: create(:exercise, track: track),
+                           user: mentee)
     create :iteration, solution: good_solution
     create :iteration, solution: bad_solution
-    create :solution_mentorship, user: user, solution: bad_solution
+    create :solution_mentorship, user: mentor, solution: bad_solution
 
-    assert_equal [good_solution].sort, SelectsSuggestedSolutionsForMentor.select(user).sort
+    assert_equal [good_solution].sort, SelectsSuggestedSolutionsForMentor.select(mentor).sort
   end
 
   test "only selects solutions that have an iteration" do
-    user, track = create_user_and_track
+    mentor, track = create_mentor_and_track
+    mentee = create_mentee([track])
 
-    bad_solution = create :solution, exercise: create(:exercise, track: track)
-    good_solution = create :solution, exercise: create(:exercise, track: track)
+    bad_solution = create(:solution,
+                          exercise: create(:exercise, track: track),
+                          user: mentee)
+    good_solution = create(:solution,
+                           exercise: create(:exercise, track: track),
+                           user: mentee)
     create :iteration, solution: good_solution
 
-    assert_equal [good_solution].sort, SelectsSuggestedSolutionsForMentor.select(user).sort
+    assert_equal [good_solution].sort, SelectsSuggestedSolutionsForMentor.select(mentor).sort
   end
 
   test "does not select solutions with >=3 mentors" do
-    user, track = create_user_and_track
+    mentor, track = create_mentor_and_track
+    mentee = create_mentee([track])
 
-    bad_solution = create :solution, exercise: create(:exercise, track: track), num_mentors: 3
-    good_solution = create :solution, exercise: create(:exercise, track: track), num_mentors: 2
+    bad_solution = create(:solution,
+                          exercise: create(:exercise, track: track),
+                          num_mentors: 3,
+                          user: mentee)
+    good_solution = create(:solution,
+                           exercise: create(:exercise, track: track),
+                           num_mentors: 2,
+                           user: mentee)
     create :iteration, solution: good_solution
     create :iteration, solution: bad_solution
 
-    assert_equal [good_solution].sort, SelectsSuggestedSolutionsForMentor.select(user).sort
+    assert_equal [good_solution].sort, SelectsSuggestedSolutionsForMentor.select(mentor).sort
   end
 
   test "does not select approved solutions" do
-    user, track = create_user_and_track
+    mentor, track = create_mentor_and_track
+    mentee = create_mentee([track])
 
-    bad_solution = create :solution, exercise: create(:exercise, track: track), approved_by: create(:user)
-    good_solution = create :solution, exercise: create(:exercise, track: track), approved_by: nil
+    bad_solution = create(:solution,
+                          exercise: create(:exercise, track: track),
+                          approved_by: create(:user),
+                          user: mentee)
+    good_solution = create(:solution,
+                           exercise: create(:exercise, track: track),
+                           approved_by: nil,
+                           user: mentee)
     create :iteration, solution: good_solution
     create :iteration, solution: bad_solution
 
-    assert_equal [good_solution].sort, SelectsSuggestedSolutionsForMentor.select(user).sort
+    assert_equal [good_solution].sort, SelectsSuggestedSolutionsForMentor.select(mentor).sort
   end
 
   test "does not select completed solutions" do
-    user, track = create_user_and_track
+    mentor, track = create_mentor_and_track
+    mentee = create_mentee([track])
 
-    bad_solution = create :solution, exercise: create(:exercise, track: track), completed_at: DateTime.now - 1.minute
-    good_solution = create :solution, exercise: create(:exercise, track: track), completed_at: nil
+    bad_solution = create(:solution,
+                          exercise: create(:exercise, track: track),
+                          completed_at: DateTime.now - 1.minute,
+                          user: mentee)
+    good_solution = create(:solution,
+                           exercise: create(:exercise, track: track),
+                           completed_at: nil,
+                           user: mentee)
     create :iteration, solution: good_solution
     create :iteration, solution: bad_solution
 
-    assert_equal [good_solution].sort, SelectsSuggestedSolutionsForMentor.select(user).sort
+    assert_equal [good_solution].sort, SelectsSuggestedSolutionsForMentor.select(mentor).sort
   end
 
   test "does not select ignored solutions" do
-    user, track = create_user_and_track
+    mentor, track = create_mentor_and_track
+    mentee = create_mentee([track])
 
-    bad_solution = create :solution, exercise: create(:exercise, track: track)
-    good_solution = create :solution, exercise: create(:exercise, track: track)
+    bad_solution = create(:solution,
+                          exercise: create(:exercise, track: track),
+                          user: mentee)
+    good_solution = create(:solution,
+                           exercise: create(:exercise, track: track),
+                           user: mentee)
     create :iteration, solution: good_solution
     create :iteration, solution: bad_solution
-    create :ignored_solution_mentorship, solution: bad_solution, user: user
+    create :ignored_solution_mentorship, solution: bad_solution, user: mentor
 
-    assert_equal [good_solution].sort, SelectsSuggestedSolutionsForMentor.select(user).sort
+    assert_equal [good_solution].sort, SelectsSuggestedSolutionsForMentor.select(mentor).sort
   end
 
   test "orders by number of mentors then time" do
-    user, track = create_user_and_track
+    mentor, track = create_mentor_and_track
+    mentee = create_mentee([track])
 
-    m2_solution_old = create :solution, exercise: create(:exercise, track: track), num_mentors: 2, last_updated_by_user_at: DateTime.now - 2.week
-    m2_solution_new = create :solution, exercise: create(:exercise, track: track), num_mentors: 2, last_updated_by_user_at: DateTime.now - 1.week
-    m0_solution_new = create :solution, exercise: create(:exercise, track: track), num_mentors: 0, last_updated_by_user_at: DateTime.now - 1.week
-    m0_solution_old = create :solution, exercise: create(:exercise, track: track), num_mentors: 0, last_updated_by_user_at: DateTime.now - 2.week
-    m1_solution_old = create :solution, exercise: create(:exercise, track: track), num_mentors: 1, last_updated_by_user_at: DateTime.now - 2.week
-    m1_solution_new = create :solution, exercise: create(:exercise, track: track), num_mentors: 1, last_updated_by_user_at: DateTime.now - 1.week
+    m2_solution_old = create(:solution,
+                             exercise: create(:exercise, track: track),
+                             num_mentors: 2,
+                             last_updated_by_user_at: DateTime.now - 2.week,
+                             user: mentee)
+    m2_solution_new = create(:solution,
+                             exercise: create(:exercise, track: track),
+                             num_mentors: 2,
+                             last_updated_by_user_at: DateTime.now - 1.week,
+                             user: mentee)
+    m0_solution_new = create(:solution,
+                             exercise: create(:exercise, track: track),
+                             num_mentors: 0,
+                             last_updated_by_user_at: DateTime.now - 1.week,
+                             user: mentee)
+    m0_solution_old = create(:solution,
+                             exercise: create(:exercise, track: track),
+                             num_mentors: 0,
+                             last_updated_by_user_at: DateTime.now - 2.week,
+                             user: mentee)
+    m1_solution_old = create(:solution,
+                             exercise: create(:exercise, track: track),
+                             num_mentors: 1,
+                             last_updated_by_user_at: DateTime.now - 2.week,
+                             user: mentee)
+    m1_solution_new = create(:solution,
+                             exercise: create(:exercise, track: track),
+                             num_mentors: 1,
+                             last_updated_by_user_at: DateTime.now - 1.week,
+                             user: mentee)
 
     [m0_solution_old, m0_solution_new, m1_solution_old, m1_solution_new, m2_solution_old, m2_solution_new].each do |solution|
       create :iteration, solution: solution
     end
 
     expected = [m0_solution_old, m0_solution_new, m1_solution_old, m1_solution_new, m2_solution_old, m2_solution_new]
-    actual = SelectsSuggestedSolutionsForMentor.select(user)
+    actual = SelectsSuggestedSolutionsForMentor.select(mentor)
 
     assert_equal actual.map(&:id), expected.map(&:id)
   end
 
-  def create_user_and_track
-    user = create :user
+  test "puts exercises in standard mode first" do
+    mentor = create(:user)
+    mentee = create(:user)
+    track = create(:track)
+    independent_track = create(:track)
+    create(:track_mentorship, user: mentor, track: track)
+    create(:track_mentorship, user: mentor, track: independent_track)
+    create(:user_track,
+           user: mentee,
+           independent_mode: true,
+           track: track)
+    create(:user_track,
+           user: mentee,
+           independent_mode: false,
+           track: independent_track)
+    exercise = create(:exercise, track: track)
+    independent_exercise = create(:exercise, track: independent_track)
+    independent_solution = create(:solution,
+                                  exercise: independent_exercise,
+                                  user: mentee)
+    solution = create(:solution, exercise: exercise, user: mentee)
+    [solution, independent_solution].each do |solution|
+      create :iteration, solution: solution
+    end
+
+    expected = [solution, independent_solution]
+    actual = SelectsSuggestedSolutionsForMentor.select(mentor)
+    assert_equal expected.map(&:id), actual.map(&:id)
+  end
+
+  def create_mentor_and_track
+    mentor = create :user
     track = create :track
-    create :track_mentorship, user: user, track: track
-    [user, track]
+    create :track_mentorship, user: mentor, track: track
+    [mentor, track]
+  end
+
+  def create_mentee(tracks)
+    mentee = create(:user)
+    tracks.each { |track| create(:user_track, track: track, user: mentee) }
+
+    mentee
   end
 end


### PR DESCRIPTION
Closes https://github.com/exercism/reboot/issues/152.

This PR places the solutions for exercises in standard mode first on the list of suggested solutions to mentor.