### PR TITLE
Prioritise core exercises

### DIFF
--- a/app/services/selects_suggested_solutions_for_mentor.rb
+++ b/app/services/selects_suggested_solutions_for_mentor.rb
@@ -43,7 +43,7 @@ class SelectsSuggestedSolutionsForMentor
       # Order standard mode tracks first,
       # then by number of mentors (least first),
       # then age (oldest first)
-      order("independent_mode DESC, num_mentors ASC, last_updated_by_user_at ASC").
+      order("independent_mode ASC, num_mentors ASC, last_updated_by_user_at ASC").
 
       includes(iterations: [], exercise: {track: []}, user: [:profile]).
 

--- a/app/services/selects_suggested_solutions_for_mentor.rb
+++ b/app/services/selects_suggested_solutions_for_mentor.rb
@@ -43,7 +43,7 @@ class SelectsSuggestedSolutionsForMentor
       # Order standard mode tracks first,
       # then by number of mentors (least first),
       # then age (oldest first)
-      order("independent_mode ASC, num_mentors ASC, last_updated_by_user_at ASC").
+      order("independent_mode ASC, core DESC, num_mentors ASC, last_updated_by_user_at ASC").
 
       includes(iterations: [], exercise: {track: []}, user: [:profile]).
 

--- a/test/services/selects_suggested_solutions_for_mentor_test.rb
+++ b/test/services/selects_suggested_solutions_for_mentor_test.rb
@@ -205,6 +205,26 @@ class SelectsSuggestedSolutionsForMentorTest < ActiveSupport::TestCase
     assert_equal expected.map(&:id), actual.map(&:id)
   end
 
+  test "puts core exercises first" do
+    mentor, track = create_mentor_and_track
+    mentee = create_mentee([track])
+
+    side_solution = create(:solution,
+                           exercise: create(:exercise, track: track, core: false),
+                           user: mentee)
+    core_solution = create(:solution,
+                           exercise: create(:exercise, track: track, core: true),
+                           user: mentee)
+    [core_solution, side_solution].each do |solution|
+      create :iteration, solution: solution
+    end
+
+    assert_equal(
+      [core_solution, side_solution],
+      SelectsSuggestedSolutionsForMentor.select(mentor)
+    )
+  end
+
   def create_mentor_and_track
     mentor = create :user
     track = create :track

--- a/test/services/selects_suggested_solutions_for_mentor_test.rb
+++ b/test/services/selects_suggested_solutions_for_mentor_test.rb
@@ -185,11 +185,11 @@ class SelectsSuggestedSolutionsForMentorTest < ActiveSupport::TestCase
     create(:user_track,
            user: mentee,
            independent_mode: true,
-           track: track)
+           track: independent_track)
     create(:user_track,
            user: mentee,
            independent_mode: false,
-           track: independent_track)
+           track: track)
     exercise = create(:exercise, track: track)
     independent_exercise = create(:exercise, track: independent_track)
     independent_solution = create(:solution,


### PR DESCRIPTION
When merged, this should close https://github.com/exercism/reboot/issues/78.

This PR puts solutions to core exercises on the top of the list of suggested solutions to mentor. Also, while I was working on this, I noticed that the solutions to independent mode exercises appear before solutions to standard mode exercises. I decided to put it also in this PR since it is a minor change.