### PR TITLE
Send notification for an auto approved exercise

### DIFF
--- a/app/services/creates_iteration.rb
+++ b/app/services/creates_iteration.rb
@@ -27,6 +27,14 @@ class CreatesIteration
 
     if solution.exercise.auto_approve?
       solution.update(approved_by: user)
+      CreatesNotification.create!(
+        solution.user,
+        :exercise_auto_approved,
+        "Your solution to <strong>#{solution.exercise.title}</strong> on the "\
+        "<strong>#{solution.exercise.track.title}</strong> track has been "\
+        "auto approved.",
+        Rails.application.routes.url_helpers.my_solution_url(solution),
+        about: solution)
     else
       solution.mentorships.update_all(requires_action: true)
       notify_mentors

--- a/app/services/creates_notification.rb
+++ b/app/services/creates_notification.rb
@@ -11,6 +11,7 @@ class CreatesNotification
     new_reaction
     new_discussion_post_for_mentor
     new_iteration_for_mentor
+    exercise_auto_approved
   }
 
   def self.create!(*args)

--- a/test/services/creates_iteration_test.rb
+++ b/test/services/creates_iteration_test.rb
@@ -116,6 +116,23 @@ class CreatesIterationTest < ActiveSupport::TestCase
     assert solution.user, solution.approved_by
   end
 
+  test "sends a notification when a solution is auto approved" do
+    exercise = create :exercise, auto_approve: true
+    solution = create :solution, exercise: exercise
+
+    CreatesNotification.
+      expects(:create!).
+      with(solution.user,
+           :exercise_auto_approved,
+           "Your solution to <strong>#{solution.exercise.title}</strong> on the "\
+           "<strong>#{solution.exercise.track.title}</strong> track has been "\
+           "auto approved.",
+            Rails.application.routes.url_helpers.my_solution_url(solution),
+            about: solution)
+
+    CreatesIteration.create!(solution, [])
+  end
+
   test "works for not-duplicate files" do
     filename1 = "foobar"
     filename2 = "barfoo"


### PR DESCRIPTION
## Description
When this PR is merged, https://github.com/exercism/reboot/issues/82 should be closed.

This implements sending a notification whenever a solution to an auto approved exercise is submitted.

## Screenshots
<img width="804" alt="screen shot 2017-11-16 at 5 18 44 pm" src="https://user-images.githubusercontent.com/1901520/32883504-8ee5ff44-caf2-11e7-892d-889bae9d9e16.png">