### PR TITLE
Fix bug with Git::SeedsTracks calling the wrong class

### DIFF
--- a/app/services/git/fetches_repo.rb
+++ b/app/services/git/fetches_repo.rb
@@ -1,0 +1,25 @@
+class Git::FetchesRepo
+  ERROR_BACKOFF_PERIOD = 10.seconds
+
+  def self.fetch(repo)
+    new(repo).fetch
+  end
+
+  def initialize(repo)
+    @repo = repo
+  end
+
+  def fetch
+    Rails.logger.info "Fetching #{repo.repo_url}"
+    repo.fetch!
+    Rails.logger.info "Done #{repo.repo_url}. Current HEAD commit is #{repo.head}"
+  rescue => e
+    Rails.logger.error "Exception while fetching repo"
+    Rails.logger.error e.message
+    Rails.logger.error e.backtrace
+    sleep ERROR_BACKOFF_PERIOD
+  end
+
+  private
+  attr_reader :repo
+end

--- a/app/services/git/fetches_repos.rb
+++ b/app/services/git/fetches_repos.rb
@@ -1,6 +1,4 @@
 class Git::FetchesRepos
-
-  ERROR_BACKOFF_PERIOD = 10.seconds
   FETCH_BACKOFF_PERIOD = 1.second
 
   def self.fetch(repos)
@@ -13,22 +11,11 @@ class Git::FetchesRepos
 
   def fetch
     repos.each do |repo|
-      fetch_repo(repo)
+      Git::FetchesRepo.fetch(repo)
       sleep FETCH_BACKOFF_PERIOD
     end
   end
 
   private
   attr_reader :repos
-
-  def fetch_repo(repo)
-    Rails.logger.info "Fetching #{repo.repo_url}"
-    repo.fetch!
-    Rails.logger.info "Done #{repo.repo_url}. Current HEAD commit is #{repo.head}"
-  rescue => e
-    Rails.logger.error "Exception while fetching repo"
-    Rails.logger.error e.message
-    Rails.logger.error e.backtrace
-    sleep ERROR_BACKOFF_PERIOD
-  end
 end

--- a/app/services/git/seeds_tracks.rb
+++ b/app/services/git/seeds_tracks.rb
@@ -2,6 +2,10 @@ class Git::SeedsTracks
 
   # NB generate this with Trackler.tracks.select(&:active?).map {|t| "https://github.com/exercism/#{t.id}" }
 
+  def self.tracks
+    TRACKS
+  end
+
   TRACKS = %w{
     https://github.com/exercism/csharp
     https://github.com/exercism/cpp
@@ -44,7 +48,7 @@ class Git::SeedsTracks
   }
 
   def self.seed!
-    new(TRACKS).seed!
+    new(tracks).seed!
   end
 
   attr_reader :repository_urls
@@ -60,7 +64,7 @@ class Git::SeedsTracks
     Track.find_each do |track|
       puts "===== Fetching #{track.slug} ====="
       begin
-        Git::FetchTrack.sync!(track)
+        Git::FetchesRepo.fetch(track.repo)
       rescue => e
         puts e.message
       end

--- a/test/services/git/fetches_repo_test.rb
+++ b/test/services/git/fetches_repo_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class Git::FetchesRepoTest < ActiveSupport::TestCase
+  test "fetches repo" do
+    repo = mock()
+    repo.stubs(:repo_url)
+    repo.stubs(:head)
+
+    repo.expects(:fetch!)
+
+    Git::FetchesRepo.fetch(repo)
+  end
+end

--- a/test/services/git/fetches_repos_test.rb
+++ b/test/services/git/fetches_repos_test.rb
@@ -3,10 +3,8 @@ require 'test_helper'
 class Git::FetchesReposTest < ActiveSupport::TestCase
   test "fetches repos" do
     repo = mock()
-    repo.stubs(:repo_url)
-    repo.stubs(:head)
 
-    repo.expects(:fetch!)
+    Git::FetchesRepo.expects(:fetch).with(repo)
 
     Git::FetchesRepos.fetch([repo])
   end

--- a/test/services/git/seeds_tracks_test.rb
+++ b/test/services/git/seeds_tracks_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class Git::SeedsTracksTest < ActiveSupport::TestCase
+  test "seeds tracks" do
+    track = create(:track)
+    exercise = create(:exercise, slug: "hello-world", track: track)
+    Git::SeedsTracks.stubs(:tracks).returns([nil])
+
+    Git::SeedsTrack.expects(:seed!).with(nil)
+    Git::FetchesRepo.expects(:fetch).with(track.repo)
+    Git::SyncsTrack.expects(:sync!).with(track)
+
+    Git::SeedsTracks.seed!
+
+    exercise.reload
+    assert exercise.auto_approve?
+  end
+end


### PR DESCRIPTION
When I was setting up a fresh repository, I noticed that `Git::SeedsTracks` was calling a non existent class called `Git::FetchTrack`.