### PR TITLE
Bugfix: Display solutions ordered by reactions in exercise page

### DIFF
--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -10,7 +10,7 @@ class ExercisesController < ApplicationController
   def show
     @track = Track.find(params[:track_id])
     @exercise = @track.exercises.find(params[:id])
-    @solutions = @exercise.solutions.published.reorder('num_reactions DESC').includes(:user).limit(6)
+    @solutions = @exercise.solutions.published.reorder(num_reactions: :desc).includes(:user).limit(6)
 
     @reaction_counts = Reaction.where(solution_id: @solutions.map(&:id)).group(:solution_id, :emotion).count
     @comment_counts = Reaction.where(solution_id: @solutions.map(&:id)).with_comments.group(:solution_id).count

--- a/test/system/exercises_test.rb
+++ b/test/system/exercises_test.rb
@@ -1,0 +1,25 @@
+require 'application_system_test_case'
+
+class ExercisesTest < ApplicationSystemTestCase
+  test "shows exercise solutions ordered by number of reactions" do
+    exercise = create(:exercise)
+    solution1 = create(:solution,
+                       num_reactions: 2,
+                       exercise: exercise,
+                       published_at: Time.current)
+    solution2 = create(:solution,
+                       num_reactions: 1,
+                       exercise: exercise,
+                       published_at: Time.current)
+    expected_solutions = [solution1, solution2]
+
+    visit track_exercise_path(exercise.track, exercise)
+
+    actual_solutions = page.
+      find_all(".solution").
+      map { |solution| solution[:href] }
+    0..actual_solutions.length do |i|
+      assert_match expected_solutions[i], actual_solutions[i]
+    end
+  end
+end


### PR DESCRIPTION
This fix should close this [Bugsnag issue](https://app.bugsnag.com/exercism/exercism-v2/errors/59a44d9867fe800018690c6c).

The error occurs because an invalid SQL statement is used when using a
string argument to order the solutions by number of reactions. Changing it to
use symbols formats the query correctly.

As there are more places where we use string arguments to order the
solutions, we should check whether they return the same bug.