### PR TITLE
Fix runtime error on db:seed

### DIFF
--- a/app/services/git/syncs_track.rb
+++ b/app/services/git/syncs_track.rb
@@ -82,9 +82,9 @@ class Git::SyncsTrack
     @unlocked_by_relationships[exercise_uuid] = unlocked_by unless unlocked_by.nil?
 
     # Some tracks have old config without keys and others
-    # have new config with keys. Using fetch helps us out
-    # with some sensible defaults where we're on the old config
-    topic_slugs = exercise.fetch(:topics, [])
+    # have new config with keys. Even when the keys are present,
+    # they're sometimes set to null.
+    topic_slugs = exercise[:topics] || []
     topics = topic_slugs.map { |slug| Topic.find_or_create_by(slug: slug) }
 
     exercise_image_stem = exercise_slug.gsub("_", "-")


### PR DESCRIPTION
When processing a track's config, we were using

     exercise.fetch(:topics, [])

to get the topics. However, some tracks explicitly set the topics to null
if they've not defined the topics, which meant that fetch was succeeding
and not falling back to the default. This caused the map on the following
line to blow up.