### PR TITLE
Remove special-case on homepage

### DIFF
--- a/app/views/pages/index.html.haml
+++ b/app/views/pages/index.html.haml
@@ -39,7 +39,7 @@
           .row{class: idx.odd?? "long" : "short"}
             -@tracks.slice!(0, idx.odd?? 10 : 9).each do |track|
               =link_to track, class: "track #{track.slug=="go"?"go":""}", style: "background-image:url('#{track.hex_white_icon_url}')" do
-                .title= track.slug == "lfe" ? "LFE" : track.title
+                .title= track.title
                 -if track.slug == "go"
                   .left-eye
                     .pupil


### PR DESCRIPTION
The LFE track used to be named Lisp-Flavoured Erlang, causing the hexagons on
the homepage to overflow. We fixed it by special-casing to use the abbreviation
for that track.

The track was renamed, and now the track's language matches what we had hard-coded
for the work-around.

This removes the workaround.