### PR TITLE
Update db schema file per recent migrations

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -178,17 +178,17 @@ ActiveRecord::Schema.define(version: 20171107042340) do
     t.index ["user_id"], name: "fk_rails_9f02fc96a0"
   end
 
-  create_table "repo_update_fetches", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "repo_update_fetches", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.timestamp "completed_at"
     t.bigint "repo_update_id", null: false
-    t.string "host", null: false
+    t.string "host", limit: 190, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["repo_update_id", "host"], name: "index_repo_update_fetches_on_repo_update_id_and_host", unique: true
     t.index ["repo_update_id"], name: "index_repo_update_fetches_on_repo_update_id"
   end
 
-  create_table "repo_updates", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "repo_updates", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.timestamp "synced_at"
     t.string "slug", null: false
     t.datetime "created_at", null: false
@@ -225,7 +225,6 @@ ActiveRecord::Schema.define(version: 20171107042340) do
     t.integer "num_reactions", default: 0, null: false
     t.text "reflection"
     t.boolean "is_legacy", default: false, null: false
-    t.boolean "boolean", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "mentoring_enabled"


### PR DESCRIPTION
The most recent changes to the db schema file hadn't been committed.

This is the result of dropping and recreating the database, altering the encoding, and
then running the full migrations from scratch.