### PR TITLE
Add newly launched tracks

### DIFF
--- a/app/services/git/seeds_tracks.rb
+++ b/app/services/git/seeds_tracks.rb
@@ -1,6 +1,6 @@
 class Git::SeedsTracks
 
-  # NB generate this with Trackler.tracks.select(&:active?).map {|t| "https://github.com/exercism/#{t.id}" }
+  # NB generate this with Trackler.tracks.select(&:active?).map {|t| "https://github.com/exercism/#{t.id}" }.sort
 
   def self.tracks
     TRACKS

--- a/app/services/git/seeds_tracks.rb
+++ b/app/services/git/seeds_tracks.rb
@@ -7,8 +7,10 @@ class Git::SeedsTracks
   end
 
   TRACKS = %w{
+    https://github.com/exercism/c
     https://github.com/exercism/csharp
     https://github.com/exercism/cpp
+    https://github.com/exercism/cfml
     https://github.com/exercism/clojure
     https://github.com/exercism/coffeescript
     https://github.com/exercism/common-lisp
@@ -25,6 +27,7 @@ class Git::SeedsTracks
     https://github.com/exercism/haskell
     https://github.com/exercism/java
     https://github.com/exercism/javascript
+    https://github.com/exercism/julia
     https://github.com/exercism/kotlin
     https://github.com/exercism/lfe
     https://github.com/exercism/lua
@@ -35,6 +38,7 @@ class Git::SeedsTracks
     https://github.com/exercism/plsql
     https://github.com/exercism/perl5
     https://github.com/exercism/perl6
+    https://github.com/exercism/purescript
     https://github.com/exercism/python
     https://github.com/exercism/r
     https://github.com/exercism/racket
@@ -42,6 +46,7 @@ class Git::SeedsTracks
     https://github.com/exercism/rust
     https://github.com/exercism/scala
     https://github.com/exercism/scheme
+    https://github.com/exercism/sml
     https://github.com/exercism/swift
     https://github.com/exercism/typescript
     https://github.com/exercism/vimscript

--- a/app/services/git/seeds_tracks.rb
+++ b/app/services/git/seeds_tracks.rb
@@ -8,19 +8,19 @@ class Git::SeedsTracks
 
   TRACKS = %w{
     https://github.com/exercism/c
-    https://github.com/exercism/csharp
-    https://github.com/exercism/cpp
     https://github.com/exercism/cfml
     https://github.com/exercism/clojure
     https://github.com/exercism/coffeescript
     https://github.com/exercism/common-lisp
+    https://github.com/exercism/cpp
     https://github.com/exercism/crystal
+    https://github.com/exercism/csharp
     https://github.com/exercism/d
     https://github.com/exercism/delphi
     https://github.com/exercism/ecmascript
+    https://github.com/exercism/elisp
     https://github.com/exercism/elixir
     https://github.com/exercism/elm
-    https://github.com/exercism/elisp
     https://github.com/exercism/erlang
     https://github.com/exercism/fsharp
     https://github.com/exercism/go
@@ -32,12 +32,12 @@ class Git::SeedsTracks
     https://github.com/exercism/lfe
     https://github.com/exercism/lua
     https://github.com/exercism/mips
-    https://github.com/exercism/ocaml
     https://github.com/exercism/objective-c
-    https://github.com/exercism/php
-    https://github.com/exercism/plsql
+    https://github.com/exercism/ocaml
     https://github.com/exercism/perl5
     https://github.com/exercism/perl6
+    https://github.com/exercism/php
+    https://github.com/exercism/plsql
     https://github.com/exercism/purescript
     https://github.com/exercism/python
     https://github.com/exercism/r


### PR DESCRIPTION
This adds tracks that have been activated since we launched the beta.

It will mess up the homepage, which we decided was temporarily OK, because we need to be able to run the full ETL including these tracks.