### PR TITLE
Add active column to tracks table

### DIFF
--- a/db/migrate/20171231162945_add_active_column_to_tracks.rb
+++ b/db/migrate/20171231162945_add_active_column_to_tracks.rb
@@ -1,0 +1,5 @@
+class AddActiveColumnToTracks < ActiveRecord::Migration[5.1]
+  def change
+    add_column :tracks, :active, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171107042340) do
+ActiveRecord::Schema.define(version: 20171231162945) do
 
   create_table "auth_tokens", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.bigint "user_id", null: false
@@ -279,6 +279,7 @@ ActiveRecord::Schema.define(version: 20171107042340) do
     t.string "hex_white_icon_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "active", default: true, null: false
   end
 
   create_table "user_tracks", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|


### PR DESCRIPTION
This is in support of adding not-yet-launched tracks to the site. We need to deploy this and run the migration before deploying any code that relies on it.