### PR TITLE
Add support for inactive tracks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,8 +50,9 @@ group :development do
 end
 
 group :test do
-  gem 'mocha'
   gem 'minitest', '~> 5.10', '!= 5.10.2'
-  gem 'timecop'
+  gem 'minitest-stub-const'
+  gem 'mocha'
   gem 'rails-controller-testing'
+  gem 'timecop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,7 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.3.0)
     minitest (5.10.3)
+    minitest-stub-const (0.6)
     mocha (1.3.0)
       metaclass (~> 0.0.1)
     multi_json (1.12.2)
@@ -328,6 +329,7 @@ DEPENDENCIES
   lmdb
   loofah
   minitest (~> 5.10, != 5.10.2)
+  minitest-stub-const
   mocha
   mysql2
   octokit
@@ -349,4 +351,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/app/controllers/my/tracks_controller.rb
+++ b/app/controllers/my/tracks_controller.rb
@@ -2,7 +2,7 @@ class My::TracksController < MyController
   skip_before_action :authenticate_user!, only: [:show]
 
   def index
-    tracks = Track.order('title ASC')
+    tracks = Track.active.order('title ASC')
     tracks = tracks.where("title like ?", "%#{params[:title]}%") if params[:title].present?
     joined_track_ids = current_user.user_tracks.pluck(:track_id)
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -23,7 +23,7 @@ class PagesController < ApplicationController
 
   # Landing page
   def index
-    @tracks = Track.reorder("rand()").to_a
+    @tracks = Track.active.reorder("rand()").to_a
   end
 
   def team

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -2,7 +2,7 @@ class TracksController < ApplicationController
   def index
     return redirect_to [:my, :tracks] if user_signed_in?
 
-    @tracks = Track.order('title ASC')
+    @tracks = Track.active.order('title ASC')
     @all_exercise_counts = Exercise.where(track_id: @tracks).group(:track_id).count
     @all_user_tracks_counts = UserTrack.where(track_id: @tracks).group(:track_id).count
   end

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -11,6 +11,8 @@ class Track < ApplicationRecord
   has_many :mentors, through: :mentorships, source: :user
   has_many :maintainers
 
+  scope :active, ->{ where(active: true) }
+
   [:bordered_green_icon_url,
    :bordered_turquoise_icon_url,
    :hex_green_icon_url,

--- a/app/services/creates_track.rb
+++ b/app/services/creates_track.rb
@@ -1,15 +1,16 @@
 class CreatesTrack
 
-  def self.create!(language, track_slug, repo_url)
-    new(language, track_slug, repo_url).create!
+  def self.create!(language, track_slug, repo_url, active:)
+    new(language, track_slug, repo_url, active: active).create!
   end
 
-  attr_reader :language, :track_slug, :repo_url
+  attr_reader :language, :track_slug, :repo_url, :active
 
-  def initialize(language, track_slug, repo_url)
+  def initialize(language, track_slug, repo_url, active:)
     @language = language
     @repo_url = repo_url
     @track_slug = track_slug || repo_url.split("/").last
+    @active = active
   end
 
   def create!
@@ -27,6 +28,7 @@ class CreatesTrack
       slug: track_slug,
       syntax_highligher_language: prism_language,
       repo_url: repo_url,
+      active: active,
 
       # Default track metadata to empty for git syncer to populate
       introduction: "",

--- a/app/services/git/seeds_track.rb
+++ b/app/services/git/seeds_track.rb
@@ -13,7 +13,7 @@ class Git::SeedsTrack
   def seed!
     puts "Seeding #{repo_url}"
     unless Track.exists?(repo_url: repo_url)
-      CreatesTrack.create!(language, track_slug, repo_url)
+      CreatesTrack.create!(language, track_slug, repo_url, active: config[:active])
     end
   end
 

--- a/app/services/git/seeds_tracks.rb
+++ b/app/services/git/seeds_tracks.rb
@@ -7,24 +7,34 @@ class Git::SeedsTracks
   end
 
   TRACKS = %w{
+    https://github.com/exercism/bash
     https://github.com/exercism/c
+    https://github.com/exercism/ceylon
     https://github.com/exercism/cfml
     https://github.com/exercism/clojure
     https://github.com/exercism/coffeescript
     https://github.com/exercism/common-lisp
+    https://github.com/exercism/coq
     https://github.com/exercism/cpp
     https://github.com/exercism/crystal
     https://github.com/exercism/csharp
     https://github.com/exercism/d
+    https://github.com/exercism/dart
     https://github.com/exercism/delphi
     https://github.com/exercism/ecmascript
     https://github.com/exercism/elisp
     https://github.com/exercism/elixir
     https://github.com/exercism/elm
     https://github.com/exercism/erlang
+    https://github.com/exercism/factor
+    https://github.com/exercism/fortran
     https://github.com/exercism/fsharp
+    https://github.com/exercism/gnu-apl
     https://github.com/exercism/go
+    https://github.com/exercism/groovy
     https://github.com/exercism/haskell
+    https://github.com/exercism/haxe
+    https://github.com/exercism/idris
     https://github.com/exercism/java
     https://github.com/exercism/javascript
     https://github.com/exercism/julia
@@ -32,12 +42,16 @@ class Git::SeedsTracks
     https://github.com/exercism/lfe
     https://github.com/exercism/lua
     https://github.com/exercism/mips
+    https://github.com/exercism/nim
     https://github.com/exercism/objective-c
     https://github.com/exercism/ocaml
     https://github.com/exercism/perl5
     https://github.com/exercism/perl6
     https://github.com/exercism/php
     https://github.com/exercism/plsql
+    https://github.com/exercism/pony
+    https://github.com/exercism/powershell
+    https://github.com/exercism/prolog
     https://github.com/exercism/purescript
     https://github.com/exercism/python
     https://github.com/exercism/r
@@ -49,6 +63,7 @@ class Git::SeedsTracks
     https://github.com/exercism/sml
     https://github.com/exercism/swift
     https://github.com/exercism/typescript
+    https://github.com/exercism/vbnet
     https://github.com/exercism/vimscript
   }
 

--- a/db/migrate/20171231162945_add_active_column_to_tracks.rb
+++ b/db/migrate/20171231162945_add_active_column_to_tracks.rb
@@ -1,0 +1,5 @@
+class AddActiveColumnToTracks < ActiveRecord::Migration[5.1]
+  def change
+    add_column :tracks, :active, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171107042340) do
+ActiveRecord::Schema.define(version: 20171231162945) do
 
   create_table "auth_tokens", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.bigint "user_id", null: false
@@ -279,6 +279,7 @@ ActiveRecord::Schema.define(version: 20171107042340) do
     t.string "hex_white_icon_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "active", default: true, null: false
   end
 
   create_table "user_tracks", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|

--- a/test/services/creates_track_test.rb
+++ b/test/services/creates_track_test.rb
@@ -1,0 +1,15 @@
+require_relative '../test_helper'
+
+class CreatesTrackTest < ActiveSupport::TestCase
+  test "creates active and inactive tracks" do
+    track_a, track_b = nil
+
+    Exercism.stub_const(:PrismLanguages, %w(a b)) do
+      track_a = CreatesTrack.create!("A", "a", "http://a.example.com", active: true)
+      track_b = CreatesTrack.create!("B", "b", "http://b.example.com", active: false)
+    end
+
+    assert_predicate track_a, :active?
+    refute_predicate track_b, :active?
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@ require 'rails/test_help'
 require 'mocha/mini_test'
 require 'timecop'
 require 'minitest/pride'
+require 'minitest/stub_const'
 
 Rails.application.routes.default_url_options = { :host => "https://v2.exercism.io" }
 OmniAuth.config.test_mode = true


### PR DESCRIPTION
**depends on migration in https://github.com/exercism/prototype/pull/49** -- update: deployed/migrated

This stores the active flag on tracks based on their `config.json`, and supports an `active` scope on the `Track` model.

It scopes the Track collections to the active tracks on:

- the homepage
- the track list page
- the "my tracks" list page

This does not change any endpoints that act on a specific track, which means that you could go to the page for an inactive track, or fetch/submit solutions for inactive tracks, if you go to the correct URL or pass the right parameters.

Lastly, it adds all the currently inactive tracks to the list of tracks to be seeded with `rake db:seed`.