### PR TITLE
Add config for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+language: ruby
+sudo: true
+services:
+  - mysql
+  - redis-server
+addons:
+  apt:
+    sources:
+      - mysql-5.7-trusty
+    packages:
+      - mysql-server
+      - mysql-client
+before_install:
+  - sudo mysql -e "use mysql; update user set authentication_string=PASSWORD('') where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;"
+  - sudo mysql_upgrade
+  - sudo service mysql restart
+  - sudo mysql -e "CREATE USER 'exercism_reboot'@'localhost' IDENTIFIED BY 'exercism_reboot'" -u root
+  - sudo mysql -e "create database exercism_reboot_test" -u root
+  - sudo mysql -e "ALTER DATABASE exercism_reboot_test CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;" -u root
+  - sudo mysql -e "GRANT ALL PRIVILEGES ON exercism_reboot_test.* TO 'exercism_reboot'@'localhost'" -u root
+install:
+  - "bundle install"
+  - "npm install"
+  - "bundle exec rake db:test:prepare"
+script:
+  - "bundle exec rake test"
+cache:
+  - bundler
+  - node_modules


### PR DESCRIPTION
We rely on MySQL 5.7+, since our teams table has an index on slug,
which is a varchar 255 field, and due to our emoji support in general,
that means that this exceeds the maximum field size for indices in
previous versions of MySQL.

Installing MySQL 5.7 required sudo in order to install it.

Other things to note: we require both mysql and redis, and we
have tests that hit the front-end so we need to install the
node dependencies in addition to the bundler dependencies.

Note that I'm using Travis CI's new GitHub App instead of the legacy service hook. This means we get to take advantage of the new Checks API features that GitHub launched yesterday.

FYI @iHiD @kntsoriano 
I'm going to go ahead and merge this to master if/when the build passes.