### PR TITLE
Fix typo in "featured in" section of homepage

### DIFF
--- a/app/views/pages/index.html.haml
+++ b/app/views/pages/index.html.haml
@@ -17,7 +17,7 @@
 
   .pr-section
     .lo-container
-      %h2 Exercism has featured in...
+      %h2 Exercism has been featured in...
       .logos
         =link_to image_tag("pr-logos/changelog.png"), "https://changelog.com/108/", target: "blank"
         =link_to image_tag("pr-logos/codeship.png"), "http://blog.codeship.com/an-inside-look-with-codeship-katrina-owen-of-exercism-io/", target: "blank"


### PR DESCRIPTION
Hi, I noticed a small typo on the v2 homepage. The same language exists on the new mentoring site; I can open a PR there as well if this is helpful.