### PR TITLE
Send email when creating a team invite

### DIFF
--- a/app/mailers/team_invite_mailer.rb
+++ b/app/mailers/team_invite_mailer.rb
@@ -7,4 +7,13 @@ class TeamInviteMailer < ApplicationMailer
       subject: "#{@invite.inviter_name} has invited you to join Exercism"
     )
   end
+
+  def existing_user(invite)
+    @invite = invite
+
+    mail(
+      to: @invite.email,
+      subject: "#{@invite.inviter_name} has invited you to join their team"
+    )
+  end
 end

--- a/app/mailers/team_invite_mailer.rb
+++ b/app/mailers/team_invite_mailer.rb
@@ -1,0 +1,10 @@
+class TeamInviteMailer < ApplicationMailer
+  def new_user(invite)
+    @invite = invite
+
+    mail(
+      to: @invite.email,
+      subject: "#{@invite.inviter_name} has invited you to join Exercism"
+    )
+  end
+end

--- a/app/models/team_invitation.rb
+++ b/app/models/team_invitation.rb
@@ -3,6 +3,7 @@ class TeamInvitation < ApplicationRecord
   belongs_to :invited_by, class_name: "User"
 
   delegate :name, to: :invited_by, prefix: "inviter"
+  delegate :name, to: :team, prefix: true
 
   def self.for_user(user)
     self.where(email: user.email)

--- a/app/models/team_invitation.rb
+++ b/app/models/team_invitation.rb
@@ -2,6 +2,8 @@ class TeamInvitation < ApplicationRecord
   belongs_to :team
   belongs_to :invited_by, class_name: "User"
 
+  delegate :name, to: :invited_by, prefix: "inviter"
+
   def self.for_user(user)
     self.where(email: user.email)
   end

--- a/app/services/create_team_invitation.rb
+++ b/app/services/create_team_invitation.rb
@@ -2,6 +2,7 @@ class CreateTeamInvitation
   include Mandate
 
   attr_reader :team, :invited_by, :email
+
   def initialize(team, invited_by, email)
     @team = team
     @invited_by = invited_by
@@ -26,7 +27,15 @@ class CreateTeamInvitation
   end
 
   def send_invite!
-    TeamInviteMailer.new_user(invite).deliver_later
+    if existing_user?
+      TeamInviteMailer.existing_user(invite).deliver_later
+    else
+      TeamInviteMailer.new_user(invite).deliver_later
+    end
+  end
+
+  def existing_user?
+    User.find_by(email: invite.email).present?
   end
 end
 

--- a/app/services/create_team_invitation.rb
+++ b/app/services/create_team_invitation.rb
@@ -9,11 +9,24 @@ class CreateTeamInvitation
   end
 
   def call
-    team.invitations.create!(
+    create_invite!
+    send_invite!
+
+    team
+  end
+
+  private
+  attr_reader :invite
+
+  def create_invite!
+    @invite = team.invitations.create!(
       email: email,
       invited_by: invited_by
     )
-    team
+  end
+
+  def send_invite!
+    TeamInviteMailer.new_user(invite).deliver_later
   end
 end
 

--- a/app/views/team_invite_mailer/existing_user.html.haml
+++ b/app/views/team_invite_mailer/existing_user.html.haml
@@ -1,0 +1,4 @@
+.content
+  %p #{@invite.inviter_name} has invited you to join #{@invite.team_name}!
+
+  %p Join by following this #{link_to "link", teams_url}.

--- a/app/views/team_invite_mailer/existing_user.text.haml
+++ b/app/views/team_invite_mailer/existing_user.text.haml
@@ -1,0 +1,3 @@
+#{@invite.inviter_name} has invited you to join #{@invite.team_name}!
+
+Join by following this link: #{teams_url}

--- a/app/views/team_invite_mailer/new_user.html.haml
+++ b/app/views/team_invite_mailer/new_user.html.haml
@@ -1,0 +1,4 @@
+.content
+  %p #{@invite.inviter_name} has invited you to join Exercism!
+
+  %p Join by following this #{link_to "link", teams_url}.

--- a/app/views/team_invite_mailer/new_user.text.haml
+++ b/app/views/team_invite_mailer/new_user.text.haml
@@ -1,0 +1,3 @@
+#{@invite.inviter_name} has invited you to join Exercism!
+
+Join by following this link: #{teams_url}

--- a/test/mailers/previews/team_invite_mailer_preview.rb
+++ b/test/mailers/previews/team_invite_mailer_preview.rb
@@ -1,0 +1,5 @@
+class TeamInviteMailerPreview < ActionMailer::Preview
+  def new_user
+    TeamInviteMailer.new_user(TeamInvitation.first)
+  end
+end

--- a/test/mailers/previews/team_invite_mailer_preview.rb
+++ b/test/mailers/previews/team_invite_mailer_preview.rb
@@ -2,4 +2,8 @@ class TeamInviteMailerPreview < ActionMailer::Preview
   def new_user
     TeamInviteMailer.new_user(TeamInvitation.first)
   end
+
+  def existing_user
+    TeamInviteMailer.existing_user(TeamInvitation.first)
+  end
 end

--- a/test/services/create_team_invitation_test.rb
+++ b/test/services/create_team_invitation_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class CreateTeamInvitationTest < ActiveSupport::TestCase
+  test "creates team invitation" do
+    inviter = create(:user)
+    team = create(:team)
+
+    CreateTeamInvitation.(team, inviter, "test@example.com")
+
+    invite = TeamInvitation.last
+    refute_nil invite, "Expected team invitation to be created"
+    assert_equal inviter, invite.invited_by
+    assert_equal "test@example.com", invite.email
+    assert_equal team, invite.team
+  end
+end

--- a/test/services/create_team_invitation_test.rb
+++ b/test/services/create_team_invitation_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class CreateTeamInvitationTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
   test "creates team invitation" do
     inviter = create(:user)
     team = create(:team)
@@ -12,5 +14,20 @@ class CreateTeamInvitationTest < ActiveSupport::TestCase
     assert_equal inviter, invite.invited_by
     assert_equal "test@example.com", invite.email
     assert_equal team, invite.team
+  end
+
+  test "sends an email to a new user" do
+    inviter = create(:user, name: "Leader")
+    team = create(:team)
+
+    perform_enqueued_jobs do
+      CreateTeamInvitation.(team, inviter, "test@example.com")
+    end
+
+    email = ActionMailer::Base.deliveries.last
+    assert_equal "Leader has invited you to join Exercism", email.subject
+    assert_equal "test@example.com", email.to[0]
+    assert_includes email.text_part.decoded, "https://teams.exercism.io"
+    assert_includes email.html_part.decoded, "https://teams.exercism.io"
   end
 end

--- a/test/services/create_team_invitation_test.rb
+++ b/test/services/create_team_invitation_test.rb
@@ -30,4 +30,23 @@ class CreateTeamInvitationTest < ActiveSupport::TestCase
     assert_includes email.text_part.decoded, "https://teams.exercism.io"
     assert_includes email.html_part.decoded, "https://teams.exercism.io"
   end
+
+  test "sends an email to an existing user" do
+    inviter = create(:user, name: "Leader")
+    create(:user, email: "test@example.com")
+    team = create(:team)
+
+    perform_enqueued_jobs do
+      CreateTeamInvitation.(team, inviter, "test@example.com")
+    end
+
+    email = ActionMailer::Base.deliveries.last
+    assert_equal(
+      "Leader has invited you to join their team",
+      email.subject
+    )
+    assert_equal "test@example.com", email.to[0]
+    assert_includes email.text_part.decoded, "https://teams.exercism.io"
+    assert_includes email.html_part.decoded, "https://teams.exercism.io"
+  end
 end


### PR DESCRIPTION
Closes https://github.com/exercism/reboot/issues/233.

## Description
This PR sends an email when a `TeamInvitation` is created via the `CreateTeamInvitation` service. As described in the issue linked, different email content is sent whether the invitee's email has been registered or not.

## Discussion
1. I think we need to discuss what the body of these emails should be. I've just done the bare minimum. If it's not that important right now, we can amend changes in subsequent PRs.