### PR TITLE
Track fetching improvements

### DIFF
--- a/app/services/git/fetches_updated_repos.rb
+++ b/app/services/git/fetches_updated_repos.rb
@@ -26,21 +26,13 @@ class Git::FetchesUpdatedRepos
   attr_reader :repo_update, :repo_update_fetch
 
   def repo_updates
-    repo_updates_without_fetches + repo_updates_not_fetched
-  end
-
-  def repo_updates_without_fetches
-    RepoUpdate.
+    fetched = RepoUpdate.
       includes(:repo_update_fetches).
-      where(synced_at: nil).
-      where(repo_update_fetches: { repo_update_id: nil })
-  end
+      where(repo_update_fetches: { host: ClusterConfig.server_identity })
 
-  def repo_updates_not_fetched
     RepoUpdate.
-      includes(:repo_update_fetches).
       where(synced_at: nil).
-      where.not(repo_update_fetches: { host: ClusterConfig.server_identity })
+      where.not(id: fetched.pluck(:id))
   end
 
   def fetch_repo_update

--- a/test/services/git/fetches_updated_repos_test.rb
+++ b/test/services/git/fetches_updated_repos_test.rb
@@ -9,6 +9,9 @@ class Git::FetchesUpdatedReposTest < ActiveSupport::TestCase
     repo_update_fetch = create(:repo_update_fetch,
                                 repo_update: repo_update,
                                 host: host_name)
+    create(:repo_update_fetch,
+           repo_update: repo_update,
+           host: "host-2")
     ClusterConfig.stubs(:server_identity).returns(host_name)
 
     FetchRepoUpdateJob.expects(:perform_now).never


### PR DESCRIPTION
## Description
This PR contains fixes for fetching updates from tracks.

### Fix bug with fetching an already fetched repo update
We weren't able to sync tracks correctly because the `git:fetch` task crashed for one of the hosts. The reason why it crashed was that it was trying to fetch an already fetched update. In order to fix this, I had to rewrite the SQL query to look for tracks already fetched.

### Fetch all repo updates in a poll period
As we've needed to catch up with the updates we haven't fetched (due to the scenario described above), I noticed that the way we've written `git:fetch` was inefficient. It would take me a long time to get up to date with all the track updates! I've rewritten `git:fetch` to fetch all repo updates in a poll period, rather than fetching one update per poll period.