### PR TITLE
Remove team member

### DIFF
--- a/app/controllers/teams/team_memberships_controller.rb
+++ b/app/controllers/teams/team_memberships_controller.rb
@@ -2,16 +2,12 @@ class Teams::TeamMembershipsController < ApplicationController
   before_action :authenticate_user!
 
   def destroy
-    team_membership = teams_managed_members.find(params[:id])
+    team_membership = TeamMembership.
+      where(team_id: current_user.teams_managed.pluck(:id)).
+      find(params[:id])
 
     team_membership.destroy
 
     redirect_to teams_team_memberships_path(team_membership.team)
-  end
-
-  private
-
-  def teams_managed_members
-    TeamMembership.where(team_id: current_user.teams_managed.pluck(:id))
   end
 end

--- a/app/controllers/teams/team_memberships_controller.rb
+++ b/app/controllers/teams/team_memberships_controller.rb
@@ -2,10 +2,16 @@ class Teams::TeamMembershipsController < ApplicationController
   before_action :authenticate_user!
 
   def destroy
-    team_membership = TeamMembership.find(params[:id])
+    team_membership = teams_managed_members.find(params[:id])
 
     team_membership.destroy
 
     redirect_to teams_team_memberships_path(team_membership.team)
+  end
+
+  private
+
+  def teams_managed_members
+    TeamMembership.where(team_id: current_user.teams_managed.pluck(:id))
   end
 end

--- a/app/controllers/teams/team_memberships_controller.rb
+++ b/app/controllers/teams/team_memberships_controller.rb
@@ -1,0 +1,11 @@
+class Teams::TeamMembershipsController < ApplicationController
+  before_action :authenticate_user!
+
+  def destroy
+    team_membership = TeamMembership.find(params[:id])
+
+    team_membership.destroy
+
+    redirect_to teams_team_memberships_path(team_membership.team)
+  end
+end

--- a/app/controllers/teams/team_memberships_controller.rb
+++ b/app/controllers/teams/team_memberships_controller.rb
@@ -3,7 +3,7 @@ class Teams::TeamMembershipsController < ApplicationController
 
   def destroy
     team_membership = TeamMembership.
-      where(team_id: current_user.teams_managed.pluck(:id)).
+      where(team_id: current_user.managed_teams.pluck(:id)).
       find(params[:id])
 
     team_membership.destroy

--- a/app/controllers/teams/team_memberships_controller.rb
+++ b/app/controllers/teams/team_memberships_controller.rb
@@ -3,7 +3,7 @@ class Teams::TeamMembershipsController < ApplicationController
 
   def destroy
     team_membership = TeamMembership.
-      where(team_id: current_user.managed_teams.pluck(:id)).
+      where(team_id: current_user.managed_teams.select(:id)).
       find(params[:id])
 
     team_membership.destroy

--- a/app/models/team_membership.rb
+++ b/app/models/team_membership.rb
@@ -5,4 +5,6 @@ class TeamMembership < ApplicationRecord
 
   belongs_to :team
   belongs_to :user
+
+  delegate :name, to: :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,7 @@ class User < ApplicationRecord
 
   has_many :team_memberships
   has_many :teams, through: :team_memberships
+  has_many :teams_managed, -> { where(team_memberships: { admin: true }) }, through: :team_memberships, source: :team
 
   has_many :user_tracks
   has_many :tracks, through: :user_tracks

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,7 @@ class User < ApplicationRecord
 
   has_many :team_memberships
   has_many :teams, through: :team_memberships
-  has_many :teams_managed, -> { where(team_memberships: { admin: true }) }, through: :team_memberships, source: :team
+  has_many :managed_teams, -> { where(team_memberships: { admin: true }) }, through: :team_memberships, source: :team
 
   has_many :user_tracks
   has_many :tracks, through: :user_tracks

--- a/app/views/teams/memberships/index.html.haml
+++ b/app/views/teams/memberships/index.html.haml
@@ -19,7 +19,7 @@
         -@memberships.each do |membership|
           %tr
             %td= membership.name
-            -if current_team_membership.admin?
+            - if current_team_membership.admin? && membership != current_team_membership
               %td= link_to "Remove",
                 teams_team_membership_path(membership),
                 method: :delete,

--- a/app/views/teams/memberships/index.html.haml
+++ b/app/views/teams/memberships/index.html.haml
@@ -18,8 +18,11 @@
       %table
         -@memberships.each do |membership|
           %tr
-            %td= membership.user.name
+            %td= membership.name
             -if current_team_membership.admin?
-              %td= link_to "Remove", "#"
+              %td= link_to "Remove",
+                teams_team_membership_path(membership),
+                method: :delete,
+                data: { confirm: "Are you sure you want to remove #{membership.name} from your team?" }
 
     =link_to "Invite new member", [:new, :teams, @team, :invitation], class: 'pure-button'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -128,6 +128,8 @@ Rails.application.routes.draw do
     get "/" => "pages#index"
     get "dashboard" => "dashboard#index"
 
+    resources :team_memberships, only: [:destroy]
+
     resources :teams do
       resources :my_solutions do
         get :possible_exercises, on: :collection

--- a/test/controllers/teams/team_memberships_controller_test.rb
+++ b/test/controllers/teams/team_memberships_controller_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class Teams::TeamMembershipsControllerTest < ActionDispatch::IntegrationTest
+
+  test "prevents non-admins from removing team members" do
+    non_admin = create(:user)
+    member = create(:user)
+    team = create(:team)
+    create(:team_membership,
+           user: non_admin,
+           team: team,
+           admin: false)
+    membership = create(:team_membership,
+                        user: member,
+                        team: team,
+                        admin: false)
+
+    sign_in!(non_admin)
+    assert_raises(ActiveRecord::RecordNotFound) do
+      delete teams_team_membership_url(membership)
+    end
+
+    team.reload
+    assert_includes team.members, member
+  end
+end

--- a/test/models/team_membership_test.rb
+++ b/test/models/team_membership_test.rb
@@ -1,7 +1,10 @@
 require 'test_helper'
 
 class TeamMembershipTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "returns user name" do
+    user = create(:user, name: "User")
+    member = create(:team_membership, user: user)
+
+    assert_equal "User", member.name
+  end
 end

--- a/test/system/teams/remove_member_test.rb
+++ b/test/system/teams/remove_member_test.rb
@@ -1,0 +1,26 @@
+require 'application_system_test_case'
+
+class Teams::RemoveMemberTest < ApplicationSystemTestCase
+  test "team admin removes member from team" do
+    original_host = Capybara.app_host
+    Capybara.app_host = "http://teams.lvh.me"
+
+    team_admin = create(:user)
+    team = create(:team)
+    member = create(:user, name: "Team member")
+    create(:team_membership, team: team, user: team_admin, admin: true)
+    create(:team_membership, team: team, user: member, admin: false)
+
+    sign_in!(team_admin)
+    visit teams_team_memberships_path(team)
+    within("tr", text: /Team member/) do
+      accept_confirm do
+        click_on "Remove"
+      end
+    end
+
+    assert page.has_no_content?("Team member")
+
+    Capybara.app_host = original_host
+  end
+end

--- a/test/system/teams/remove_member_test.rb
+++ b/test/system/teams/remove_member_test.rb
@@ -13,10 +13,8 @@ class Teams::RemoveMemberTest < ApplicationSystemTestCase
 
     sign_in!(team_admin)
     visit teams_team_memberships_path(team)
-    within("tr", text: /Team member/) do
-      accept_confirm do
-        click_on "Remove"
-      end
+    accept_confirm do
+      click_on "Remove"
     end
 
     assert page.has_no_content?("Team member")


### PR DESCRIPTION
Closes https://github.com/exercism/reboot/issues/238.

## Description
This PR implements team member removal. This action is only allowed for team admins.

## Screencast
![jun-14-2018 19-37-57](https://user-images.githubusercontent.com/1901520/41409974-9ee63568-700a-11e8-9e69-a889bc7d1d6b.gif)
