### PR TITLE
Create team membership

### DIFF
--- a/app/services/create_team_membership.rb
+++ b/app/services/create_team_membership.rb
@@ -1,0 +1,15 @@
+class CreateTeamMembership
+  include Mandate
+
+  def initialize(user, team)
+    @user = user
+    @team = team
+  end
+
+  def call
+    TeamMembership.create!(team: team, user: user)
+  end
+
+  private
+  attr_reader :user, :team
+end

--- a/app/services/create_team_membership.rb
+++ b/app/services/create_team_membership.rb
@@ -7,9 +7,18 @@ class CreateTeamMembership
   end
 
   def call
-    TeamMembership.create!(team: team, user: user)
+    create_team_membership!
+    delete_redundant_invites!
   end
 
   private
   attr_reader :user, :team
+
+  def create_team_membership!
+    TeamMembership.create!(team: team, user: user)
+  end
+
+  def delete_redundant_invites!
+    team.invitations.for_user(user).destroy_all
+  end
 end

--- a/test/services/creates_team_membership_test.rb
+++ b/test/services/creates_team_membership_test.rb
@@ -12,4 +12,14 @@ class CreateTeamMembershipTest < ActiveSupport::TestCase
     assert_equal user, membership.user
     assert_equal team, membership.team
   end
+
+  test "deletes redundant team invites" do
+    user = create(:user)
+    team = create(:team)
+    create(:team_invitation, email: user.email, team: team)
+
+    CreateTeamMembership.(user, team)
+
+    assert_equal 0, TeamInvitation.count
+  end
 end

--- a/test/services/creates_team_membership_test.rb
+++ b/test/services/creates_team_membership_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class CreateTeamMembershipTest < ActiveSupport::TestCase
+  test "creates a team membership" do
+    user = create(:user)
+    team = create(:team)
+
+    CreateTeamMembership.(user, team)
+
+    membership = TeamMembership.last
+    refute_nil membership, "Expected team membership to be created"
+    assert_equal user, membership.user
+    assert_equal team, membership.team
+  end
+end


### PR DESCRIPTION
Closes https://github.com/exercism/reboot/issues/236.

## Description
This PR contains the `CreateTeamMembership` service described in the issue above.