### PR TITLE
Updated honeycomb render

### DIFF
--- a/app/assets/javascripts/landing-page.js
+++ b/app/assets/javascripts/landing-page.js
@@ -21,8 +21,8 @@ window.setupLandingPage = function() {
 
     honeycombHeight = $honeycomb.height()
     honeycombWidth = $honeycomb.width()
-    eyesCenterX = $leftEye.offset().left - $honeycomb.offset().left + 15
-    eyesCenterY = $leftEye.offset().top - $honeycomb.offset().top + 5
+    eyesCenterX = 0.5 * ($leftEye.offset().left + $leftEye.width() + $rightEye.offset().left - $honeycomb.offset().left)
+    eyesCenterY = $leftEye.offset().top + ($leftEye.height() / 2) - $honeycomb.offset().top
 
     spaceToLeft = honeycombWidth - (honeycombWidth - eyesCenterX)
     spaceToRight = honeycombWidth - spaceToLeft
@@ -34,20 +34,20 @@ window.setupLandingPage = function() {
       mouseToEyesOffsetX = eyesCenterX - mouseX
       if(mouseToEyesOffsetX > 0) {
         // mouse is to the left
-        $pupils.css('left', 5 - (mouseToEyesOffsetX / spaceToLeft * 5))
+        $pupils.css('left', Math.max(5 - (mouseToEyesOffsetX / spaceToLeft * 2), 0))
       } else {
         // mouse is to the right
-        $pupils.css('left', 5 + (-mouseToEyesOffsetX / spaceToRight * 5))
+        $pupils.css('left', Math.min(5 + (-mouseToEyesOffsetX / spaceToRight * 2), 9))
       }
 
       mouseY = e.pageY - $honeycomb.offset().top
       mouseToEyesOffsetY = eyesCenterY - mouseY
       if(mouseToEyesOffsetY > 0) {
-        // mouse is to the left
-        $pupils.css('top', 5 - (mouseToEyesOffsetY / spaceToTop * 5))
+        // mouse is to the top
+        $pupils.css('top', Math.max(5 - (mouseToEyesOffsetY / spaceToTop * 2), 0))
       } else {
-        // mouse is to the right
-        $pupils.css('top', 5 + (-mouseToEyesOffsetY / spaceToBottom * 5))
+        // mouse is to the bottom
+        $pupils.css('top', Math.min(5 + (-mouseToEyesOffsetY / spaceToBottom * 2), 9))
       }
 
     })

--- a/app/views/pages/_tracks_display.html.haml
+++ b/app/views/pages/_tracks_display.html.haml
@@ -1,0 +1,31 @@
+-idx = 0
+-first_row_count = 0
+
+-if ((@tracks.count % 19) < 5)
+    -# If the overflow row will contain less than 5 elements, we will add five elements to it from another row
+    -first_row_count = (@tracks.count % 19) + (5 - (@tracks.count % 19))
+-elsif ((@tracks.count % 19) > 10 && (@tracks.count % 19) < 15)
+    -# If the overflow row contains between 11 and 14 elements, we will add five elements to it from another row
+    -first_row_count = ((@tracks.count % 19) - 10) + (15 - (@tracks.count % 19))
+
+-while @tracks.present?
+    -idx += 1
+
+    -# Calculate the number of items in this row, based on the index/upper limit
+    -row_count = idx == 1 && first_row_count > 0 ? first_row_count : [(idx.odd?? 10 : 9),@tracks.count].min
+    -# Add empty items to center each row
+    -items_before = row_count <= 0 ? 0 : [(idx.odd?? (9/2 - row_count/2) : (8/2 - row_count/2)),0].max
+
+    .row{class: idx.odd?? "long" : "short"}
+        -# Empty items used for centering a row
+        -items_before.times do |track|
+            .track
+                .title=""
+        -@tracks.slice!(0, row_count).each do |track|
+            =link_to track, class: "track #{track.slug=="go"?"go":""}", style: "background-image:url('#{track.hex_white_icon_url}')" do
+                .title= track.title
+                -if track.slug == "go"
+                    .left-eye
+                        .pupil
+                    .right-eye
+                        .pupil

--- a/app/views/pages/index.html.haml
+++ b/app/views/pages/index.html.haml
@@ -33,18 +33,7 @@
         %h2 Available Language Tracks
         %p There are #{@tracks.size} different #{link_to "language tracks", tracks_path} on Exercism for you to explore. Which one will you choose to learn first?
       .tracks
-        -idx = 0
-        -while @tracks.present?
-          -idx += 1
-          .row{class: idx.odd?? "long" : "short"}
-            -@tracks.slice!(0, idx.odd?? 10 : 9).each do |track|
-              =link_to track, class: "track #{track.slug=="go"?"go":""}", style: "background-image:url('#{track.hex_white_icon_url}')" do
-                .title= track.title
-                -if track.slug == "go"
-                  .left-eye
-                    .pupil
-                  .right-eye
-                    .pupil
+        =render 'tracks_display', :tracks => @tracks
 
   .how-section
     .lo-container


### PR DESCRIPTION
I have updated the rendering of the track honeycomb display to avoid showing rows with small numbers of items, and added support for centering rows which are not completely filled.

This also updates some of the logic used in the calculation of the gopher's pupils (to restrict them to locations in the eye only)