### PR TITLE
Add track information pages

### DIFF
--- a/app/assets/stylesheets/pages/generic-page.scss
+++ b/app/assets/stylesheets/pages/generic-page.scss
@@ -19,12 +19,13 @@
     .lhs {
         padding-right:40px;
     }
-    .changes {
+    .changes, .links {
         margin-top:50px;
         padding-top:20px;
         border-top:1px solid #eee;
     }
 
+    h2,
     h3 {
         @include font-size(18, 18);
         font-weight:$regular;

--- a/app/assets/stylesheets/pages/my-solution-unlocked-page.scss
+++ b/app/assets/stylesheets/pages/my-solution-unlocked-page.scss
@@ -73,6 +73,7 @@
         padding:20px;
         border:1px solid #e5e5e5;
         border-radius:2px;
+        margin-bottom:20px;
 
         h3 {
             font-weight:$regular;
@@ -88,7 +89,7 @@
         border:1px solid $color-1;
         padding:20px;
         border-radius:2px;
-        margin-bottom:30px;
+        margin-bottom:20px;
 
         h3 {
             font-weight:$regular;
@@ -107,4 +108,23 @@
             padding:10px;
         }
     }
+
+    .page-links {
+        padding:20px;
+        border:1px solid #e5e5e5;
+        border-radius:2px;
+
+        h3 {
+            font-weight:$regular;
+            @include font-size(16, 16);
+            margin-bottom:12px;
+        }
+        a {
+            color:#333;
+        }
+        ul {
+            margin-bottom:0;
+        }
+    }
+
 }

--- a/app/assets/stylesheets/pages/page.scss
+++ b/app/assets/stylesheets/pages/page.scss
@@ -1,6 +1,0 @@
-@import 'variables';
-@import 'mixins';
-
-#generic-page {
-}
-

--- a/app/controllers/track_pages_controller.rb
+++ b/app/controllers/track_pages_controller.rb
@@ -1,0 +1,16 @@
+class TrackPagesController < ApplicationController
+  before_action :get_track
+
+  Git::ExercismRepo::PAGES.each do |page|
+    define_method page do
+      @page = page
+      @content = ParsesMarkdown.parse(@track.repo.send(page))
+      render action: "show"
+    end
+  end
+
+  private
+  def get_track
+    @track = Track.find(params[:track_id])
+  end
+end

--- a/app/helpers/track_pages_helper.rb
+++ b/app/helpers/track_pages_helper.rb
@@ -1,0 +1,16 @@
+module TrackPagesHelper
+  def title_for_track_page(track, page)
+    case page.to_sym
+    when :about
+      "About the #{track.title} Track"
+    when :installation
+      "Installing #{track.title}"
+    when :learning
+      "Learning #{track.title}"
+    when :tests
+      "Running the Tests"
+    when :resources
+      "Useful #{track.title} Resources"
+    end
+  end
+end

--- a/app/models/git/exercism_repo.rb
+++ b/app/models/git/exercism_repo.rb
@@ -1,4 +1,5 @@
 class Git::ExercismRepo < Git::RepoBase
+  PAGES = %w{about installation tests learning resources}
 
   def self.current_head(repo_url)
     new(repo_url).head
@@ -12,8 +13,14 @@ class Git::ExercismRepo < Git::RepoBase
     read_snippet(head_commit)
   end
 
-  def about
-    read_about(head_commit)
+  PAGES.each do |page|
+    define_method "#{page}_present?" do
+      send(page).present?
+    end
+
+    define_method page do
+      send("read_#{page}", head_commit)
+    end
   end
 
   def config
@@ -60,12 +67,18 @@ class Git::ExercismRepo < Git::RepoBase
 
   private
 
-  def read_about(commit)
-    read_docs(commit, "ABOUT.md")
-  end
-
   def read_snippet(commit)
     read_docs(commit, "SNIPPET.txt")
+  end
+
+  PAGES.each do |page|
+    define_method "read_#{page}" do |commit|
+      read_docs(commit, "#{page.upcase}.md")
+    end
+  end
+
+  def read_installation(commit)
+    read_docs(commit, "INSTALLATION.md")
   end
 
   def read_docs(commit, file_name)

--- a/app/models/git/exercism_repo.rb
+++ b/app/models/git/exercism_repo.rb
@@ -1,5 +1,6 @@
 class Git::ExercismRepo < Git::RepoBase
-  PAGES = %w{about installation tests learning resources}
+  PAGES = %w{installation tests learning resources}
+  GIT_PAGE_FILES = %w{about} + PAGES
 
   def self.current_head(repo_url)
     new(repo_url).head
@@ -13,7 +14,7 @@ class Git::ExercismRepo < Git::RepoBase
     read_snippet(head_commit)
   end
 
-  PAGES.each do |page|
+  GIT_PAGE_FILES.each do |page|
     define_method "#{page}_present?" do
       send(page).present?
     end
@@ -71,7 +72,7 @@ class Git::ExercismRepo < Git::RepoBase
     read_docs(commit, "SNIPPET.txt")
   end
 
-  PAGES.each do |page|
+  GIT_PAGE_FILES.each do |page|
     define_method "read_#{page}" do |commit|
       read_docs(commit, "#{page.upcase}.md")
     end

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -32,7 +32,7 @@ class Track < ApplicationRecord
   end
 
   def about
-    ParsesMarkdown.parse(super)
+    ParsesMarkdown.parse(repo.about)
   end
 
   def repo

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -1,5 +1,6 @@
 class Track < ApplicationRecord
   extend FriendlyId
+
   friendly_id :slug, use: [:history]
 
   has_many :testimonials

--- a/app/services/creates_track.rb
+++ b/app/services/creates_track.rb
@@ -32,7 +32,6 @@ class CreatesTrack
 
       # Default track metadata to empty for git syncer to populate
       introduction: "",
-      about: "",
       code_sample: "",
       bordered_green_icon_url: track_image_url("#{track_slug}-bordered-green.png"),
       bordered_turquoise_icon_url: track_image_url("#{track_slug}-bordered-turquoise.png"),

--- a/app/services/git/syncs_track.rb
+++ b/app/services/git/syncs_track.rb
@@ -124,10 +124,6 @@ class Git::SyncsTrack
     config[:blurb] || ""
   end
 
-  def track_about
-    repo.about || ""
-  end
-
   def code_sample
     code_sample = repo.snippet_file
     return code_sample unless code_sample.nil?

--- a/app/views/my/solutions/show_unlocked.html.haml
+++ b/app/views/my/solutions/show_unlocked.html.haml
@@ -13,6 +13,12 @@
           %h3 Get started
           %p We've created a step-by-step set of instructions to help you quickly install Exercism and get started, so you can start learning.
           =link_to "Begin Walk-Through", walkthrough_my_solution_path(@solution), remote: true, class: 'pure-button'
+
         .experienced
           %h3 Been here before?
           =render "widgets/code_snippet", code: @exercise.download_command
+
+        .page-links
+          %h3 Still Stuck?
+          %p These guides should help you.
+          =render "track_pages/links", track: @track, target: "_blank"

--- a/app/views/pages/generic.html.haml
+++ b/app/views/pages/generic.html.haml
@@ -3,10 +3,10 @@
     .lo-container
       =link_to "Home", root_path
       =image_tag "nav-divider.png"
-      %span #{@title}
+      %span= @page_title
   .header
     .lo-container
-      %h1= @title
+      %h1= @page_title
   .lo-container
     .pure-g
       .pure-u-2-3.lhs
@@ -15,7 +15,7 @@
           %h3 Something need changing on this page?
           %p
             If you've spotted something incorrect or missing from this page,
-            please #{link_to "edit this file on GitHub", "https://github.com/exercism/website-copy/blob/master/pages/#{@page}.md"}. That will submit a pull request to the website team, which we can then review and push live. 
+            please #{link_to "edit this file on GitHub", "https://github.com/exercism/website-copy/blob/master/pages/#{@page}.md"}. That will submit a pull request to the website team, which we can then review and push live.
           %p Thank you!!
       .pure-u-1-3
         =code_person_widget

--- a/app/views/track_pages/_links.html.haml
+++ b/app/views/track_pages/_links.html.haml
@@ -1,0 +1,8 @@
+-target ||= ""
+%ul.track-page-links
+  -Git::ExercismRepo::PAGES.each do |page|
+    -if track.repo.send("#{page}_present?")
+      %li= link_to title_for_track_page(track, page), send("track_#{page}_page_path", track), target: target
+
+  /%li= link_to "Getting Help", "#"
+  /%li= link_to "Remind me how to set up the CLI", "#"

--- a/app/views/track_pages/show.html.haml
+++ b/app/views/track_pages/show.html.haml
@@ -1,0 +1,25 @@
+-title = title_for_track_page(@track, @page)
+#generic-page
+  #nav.lo-nav-bar
+    .lo-container
+      =link_to "Language Tracks", [:my, :tracks]
+      =image_tag "nav-divider.png"
+      =link_to "#{@track.title} Track", [:my, @track]
+      =image_tag "nav-divider.png"
+      %span= title
+
+  .header
+    .lo-container
+      %h1= title
+
+  .lo-container
+    .pure-g
+      .pure-u-2-3.lhs
+        .content=raw @content
+
+        .links
+          %h3 More #{@track.title} resources
+          =render "links", track: @track
+
+      .pure-u-1-3
+        =code_person_widget

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,6 +77,10 @@ Rails.application.routes.draw do
     end
     resources :maintainers, only: [:index]
     resources :mentors, only: [:index]
+
+    Git::ExercismRepo::PAGES.each do |page|
+      get page => "track_pages##{page}", as: "#{page}_page"
+    end
   end
 
   # ######## #

--- a/config/skylight.yml
+++ b/config/skylight.yml
@@ -1,0 +1,3 @@
+---
+# The authentication token for the application.
+authentication: Tcw-2XrolIldt89XP85-sc4ccwqtOJ1-pYPYKzoRMs4

--- a/db/migrate/20180621150555_remove_about_from_tracks.rb
+++ b/db/migrate/20180621150555_remove_about_from_tracks.rb
@@ -1,0 +1,5 @@
+class RemoveAboutFromTracks < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :tracks, :about
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180617190428) do
+ActiveRecord::Schema.define(version: 20180621150555) do
 
   create_table "auth_tokens", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.bigint "user_id", null: false
@@ -321,7 +321,6 @@ ActiveRecord::Schema.define(version: 20180617190428) do
     t.string "title", null: false
     t.string "repo_url", null: false
     t.text "introduction", null: false
-    t.text "about", null: false
     t.text "code_sample", null: false
     t.string "syntax_highligher_language", null: false
     t.string "bordered_green_icon_url"

--- a/test/controllers/my/solutions_controller_test.rb
+++ b/test/controllers/my/solutions_controller_test.rb
@@ -6,11 +6,16 @@ class SolutionsControllerTest < ActionDispatch::IntegrationTest
     @mock_exercise = stub(
       instructions: "instructions",
       test_suite: { "test_file" => "test_suite" },
-      files: []
+      files: [],
+      about_present: false
     )
-    @mock_repo = stub( exercise: @mock_exercise)
+
+    @mock_repo = stub(exercise: @mock_exercise)
     Git::Exercise.stubs(new: @mock_exercise)
     Git::ExercismRepo.stubs(new: @mock_repo)
+    Git::ExercismRepo::PAGES.each do |page|
+      @mock_repo.stubs("#{page}_present?", false)
+    end
   end
 
   {
@@ -22,6 +27,7 @@ class SolutionsControllerTest < ActionDispatch::IntegrationTest
     test "shows with status #{status}" do
       sign_in!
       solution = send("create_#{status}_solution")
+      solution.exercise.track.stubs(repo: @mock_repo)
       create :user_track, user: @current_user, track: solution.exercise.track
 
       get my_solution_url(solution)

--- a/test/controllers/my/tracks_controller_test.rb
+++ b/test/controllers/my/tracks_controller_test.rb
@@ -9,6 +9,7 @@ class TracksControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "show logged out redirects" do
+    Track.any_instance.stubs(repo: repo_mock)
     track = create :track
     get my_track_url(track)
     assert_redirected_to track_url(track)
@@ -16,6 +17,8 @@ class TracksControllerTest < ActionDispatch::IntegrationTest
 
   test "show locked renders" do
     sign_in!
+
+    Track.any_instance.stubs(repo: repo_mock)
     get my_track_url(create :track)
     assert_response :success
     assert_correct_page "my-track-not-joined-page"

--- a/test/controllers/tracks_controller_test.rb
+++ b/test/controllers/tracks_controller_test.rb
@@ -8,6 +8,7 @@ class TracksControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "show renders" do
+    Track.any_instance.stubs(repo: repo_mock)
     get track_url(create :track)
     assert_response :success
     assert_correct_page "track-page"

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -116,11 +116,11 @@ FactoryBot.define do
     slug { "ruby-#{SecureRandom.uuid}" }
     syntax_highligher_language { slug }
     introduction "Master the Ruby language"
-    about "Placeholder about Ruby"
     code_sample <<-EOS
       puts "Hello World"
     EOS
     repo_url { "http://example.com/ruby-#{SecureRandom.uuid}.git" }
+
   end
 
   factory :exercise do

--- a/test/integration/auth_flows_test.rb
+++ b/test/integration/auth_flows_test.rb
@@ -6,6 +6,7 @@ class AuthFlowsTest < ActionDispatch::IntegrationTest
     user = create :user, password: password
     user.confirm
 
+    Track.any_instance.stubs(repo: repo_mock)
     track = create :track
     get track_path(track)
     assert_response :success
@@ -39,6 +40,7 @@ class AuthFlowsTest < ActionDispatch::IntegrationTest
     user = create :user, provider: provider, uid: uid
     user.confirm
 
+    Track.any_instance.stubs(repo: repo_mock)
     track = create :track
     get track_path(track)
     assert_response :success
@@ -60,6 +62,7 @@ class AuthFlowsTest < ActionDispatch::IntegrationTest
     provider = "foobar"
     uid = "12321321"
 
+    Track.any_instance.stubs(repo: repo_mock)
     track = create :track
     get track_path(track)
     assert_response :success
@@ -84,6 +87,7 @@ class AuthFlowsTest < ActionDispatch::IntegrationTest
     password = "foobar"
     user = create :user, password: password
 
+    Track.any_instance.stubs(repo: repo_mock)
     track = create :track
     get track_path(track)
     assert_response :success
@@ -107,6 +111,7 @@ class AuthFlowsTest < ActionDispatch::IntegrationTest
     uid = "12321321"
     email = "#{SecureRandom.uuid}@erwerew.com"
 
+    Track.any_instance.stubs(repo: repo_mock)
     track = create :track
     get track_path(track)
     assert_response :success

--- a/test/models/git/exercism_repo_test.rb
+++ b/test/models/git/exercism_repo_test.rb
@@ -1,6 +1,15 @@
 require "test_helper"
 
 class Git::ExercismRepoTest < ActiveSupport::TestCase
+  test "check about works" do
+    content = mock
+    head = "SOME_HEAD_SHA"
+    repo = Git::ExercismRepo.new("https://github.com/exercism/go")
+    repo.expects(:head_commit).returns(head)
+    repo.expects(:read_docs).with(head, "ABOUT.md").returns(content)
+    assert_equal content, repo.about
+  end
+
   test "equal when repo urls are the same" do
     repo = Git::ExercismRepo.new("https://github.com/exercism/go")
     another_repo = Git::ExercismRepo.new("https://github.com/exercism/go")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -30,4 +30,13 @@ class ActionDispatch::IntegrationTest
   def assert_correct_page(page)
     assert_includes @response.body, "<div id='#{page}'>"
   end
+
+  def repo_mock
+    content = ""
+    head = "SOME_HEAD_SHA"
+    repo = Git::ExercismRepo.new("https://github.com/exercism/go")
+    repo.stubs(:head_commit).returns(head)
+    repo.stubs(:read_docs).with(head, "ABOUT.md").returns(content)
+    repo
+  end
 end


### PR DESCRIPTION
I've written this then refactored it via meta-programming this. I think it's all fine as a first pass, but let me know if there's anything that raises alarm-bells pls. Thanks :)

Pages look like this:

<img width="1258" alt="screen shot 2018-06-21 at 15 35 08" src="https://user-images.githubusercontent.com/286476/41725900-dd8d54d2-7568-11e8-8845-7b8bb9efb450.png">
....
<img width="1033" alt="screen shot 2018-06-21 at 15 35 12" src="https://user-images.githubusercontent.com/286476/41725933-ed851ea6-7568-11e8-896f-a348c3dab55c.png">

---

The links on the new solution pages look like this:
<img width="1195" alt="screen shot 2018-06-21 at 15 36 38" src="https://user-images.githubusercontent.com/286476/41725950-f5b66bde-7568-11e8-8c8d-75e8f2c323f6.png">
