### PR TITLE
Add common-lisp file mapping to prism.

### DIFF
--- a/config/initializers/prism.rb
+++ b/config/initializers/prism.rb
@@ -201,6 +201,7 @@ Exercism::PrismFileMappings = {
   "clike": %w{},
   "cpp": %w{},
   "coffeescript": %w{},
+  "common-lisp": %w{lisp},
   "crystal": %w{},
   "css-extras": %w{},
   "d": %w{},


### PR DESCRIPTION
This PR adds the missing common-lisp mapping to the highlighter. Raised for https://github.com/exercism/v2-feedback/issues/170 