### PR TITLE
Change core exercise unlocking

### DIFF
--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -29,6 +29,10 @@ class Exercise < ApplicationRecord
     !core
   end
 
+  def unlocked_by_user?(user)
+    solutions.find_by(user: user).present?
+  end
+
   def topic_names
     @topic_names ||= topics.pluck(:name).map(&:downcase)
   end

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -20,6 +20,17 @@ class Exercise < ApplicationRecord
   scope :core, -> { where(core: true) }
   scope :side, -> { where(core: false) }
 
+  scope :locked_for, -> (user) {
+    joins(
+      sanitize_sql_array([
+        "LEFT OUTER JOIN `solutions` ON `solutions`.`exercise_id` = `exercises`.`id` AND `solutions`.`user_id` = ?",
+        user.id
+      ])
+    ).
+    where(solutions: { id: nil }).
+    where(core: true)
+  }
+
   # BETA
   def download_command
     "nextercism download #{slug} --track=#{track.slug}"

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -21,13 +21,7 @@ class Exercise < ApplicationRecord
   scope :side, -> { where(core: false) }
 
   scope :locked_for, -> (user) {
-    joins(
-      sanitize_sql_array([
-        "LEFT OUTER JOIN `solutions` ON `solutions`.`exercise_id` = `exercises`.`id` AND `solutions`.`user_id` = ?",
-        user.id
-      ])
-    ).
-    where(solutions: { id: nil }).
+    where.not(id: user.solutions.select(:exercise_id)).
     where(core: true)
   }
 
@@ -41,7 +35,7 @@ class Exercise < ApplicationRecord
   end
 
   def unlocked_by_user?(user)
-    solutions.find_by(user: user).present?
+    solutions.where(user_id: user.id).exists?
   end
 
   def topic_names

--- a/app/models/solution.rb
+++ b/app/models/solution.rb
@@ -11,7 +11,7 @@ class Solution < ApplicationRecord
 
   has_many :reactions
 
-  delegate :auto_approve?, to: :exercise
+  delegate :auto_approve?, :track, to: :exercise
 
   def self.completed
     where.not(completed_at: nil)

--- a/app/services/completes_solution.rb
+++ b/app/services/completes_solution.rb
@@ -42,19 +42,7 @@ class CompletesSolution
   end
 
   def unlock_next_core_exercise
-    next_exercise = solution.exercise.track.exercises.where(core: true).
-                      reorder('position ASC').
-                      where("position > ?", solution.exercise.position).
-                      first
-    if next_exercise
-      # Don't double-create
-      unless user.solutions.where(exercise_id: next_exercise.id).exists?
-        CreatesSolution.create!(user, next_exercise)
-      end
-    else
-      # TODO - complete track
-      raise "Not Implemented"
-    end
+    UnlocksNextCoreExercise.(solution)
   end
 
   def user

--- a/app/services/completes_solution.rb
+++ b/app/services/completes_solution.rb
@@ -42,7 +42,7 @@ class CompletesSolution
   end
 
   def unlock_next_core_exercise
-    UnlocksNextCoreExercise.(solution)
+    UnlocksNextCoreExercise.(solution.track, solution.user)
   end
 
   def user

--- a/app/services/unlocks_core_exercise.rb
+++ b/app/services/unlocks_core_exercise.rb
@@ -1,0 +1,17 @@
+class UnlocksCoreExercise
+  include Mandate
+
+  def initialize(user, exercise)
+    @user = user
+    @exercise = exercise
+  end
+
+  def call
+    return if exercise.unlocked_by_user?(user)
+
+    CreatesSolution.create!(user, exercise)
+  end
+
+  private
+  attr_reader :exercise, :user
+end

--- a/app/services/unlocks_next_core_exercise.rb
+++ b/app/services/unlocks_next_core_exercise.rb
@@ -11,8 +11,7 @@ class UnlocksNextCoreExercise
                       where("position > ?", exercise.position).
                       first
     if next_exercise
-      # Don't double-create
-      unless user.solutions.where(exercise_id: next_exercise.id).exists?
+      unless next_exercise.unlocked_by_user?(user)
         CreatesSolution.create!(user, next_exercise)
       end
     else

--- a/app/services/unlocks_next_core_exercise.rb
+++ b/app/services/unlocks_next_core_exercise.rb
@@ -8,10 +8,14 @@ class UnlocksNextCoreExercise
   def call
     return if core_exercises_in_progress?
 
-    next_exercise = exercise.track.exercises.where(core: true).
-                      reorder('position ASC').
-                      where("position > ?", exercise.position).
-                      first
+    next_exercise = exercise.
+      track.
+      exercises.
+      joins("LEFT OUTER JOIN `solutions` ON `solutions`.`exercise_id` = `exercises`.`id` AND `solutions`.`user_id` = #{user.id}").
+      where(solutions: { id: nil }).
+      order(:position).
+      first
+
     if next_exercise
       UnlocksCoreExercise.(user, next_exercise)
     else

--- a/app/services/unlocks_next_core_exercise.rb
+++ b/app/services/unlocks_next_core_exercise.rb
@@ -1,15 +1,15 @@
 class UnlocksNextCoreExercise
   include Mandate
 
-  def initialize(solution)
-    @solution = solution
+  def initialize(track, user)
+    @track = track
+    @user = user
   end
 
   def call
     return if core_exercises_in_progress?
 
-    next_exercise = exercise.
-      track.
+    next_exercise = track.
       exercises.
       joins("LEFT OUTER JOIN `solutions` ON `solutions`.`exercise_id` = `exercises`.`id` AND `solutions`.`user_id` = #{user.id}").
       where(solutions: { id: nil }).
@@ -25,16 +25,13 @@ class UnlocksNextCoreExercise
   end
 
   private
-  attr_reader :solution
-
-  delegate :user, to: :solution
-  delegate :exercise, to: :solution
+  attr_reader :track, :user
 
   def core_exercises_in_progress?
     user.
       solutions.
       joins(:exercise).
-      where(exercises: { track: exercise.track, core: true }).
+      where(exercises: { track: track, core: true }).
       where(completed_at: nil).
       exists?
   end

--- a/app/services/unlocks_next_core_exercise.rb
+++ b/app/services/unlocks_next_core_exercise.rb
@@ -11,9 +11,7 @@ class UnlocksNextCoreExercise
                       where("position > ?", exercise.position).
                       first
     if next_exercise
-      unless next_exercise.unlocked_by_user?(user)
-        CreatesSolution.create!(user, next_exercise)
-      end
+      UnlocksCoreExercise.(user, next_exercise)
     else
       # TODO - complete track
       raise "Not Implemented"

--- a/app/services/unlocks_next_core_exercise.rb
+++ b/app/services/unlocks_next_core_exercise.rb
@@ -1,0 +1,29 @@
+class UnlocksNextCoreExercise
+  include Mandate
+
+  def initialize(solution)
+    @solution = solution
+  end
+
+  def call
+    next_exercise = exercise.track.exercises.where(core: true).
+                      reorder('position ASC').
+                      where("position > ?", exercise.position).
+                      first
+    if next_exercise
+      # Don't double-create
+      unless user.solutions.where(exercise_id: next_exercise.id).exists?
+        CreatesSolution.create!(user, next_exercise)
+      end
+    else
+      # TODO - complete track
+      raise "Not Implemented"
+    end
+  end
+
+  private
+  attr_reader :solution
+
+  delegate :user, to: :solution
+  delegate :exercise, to: :solution
+end

--- a/app/services/unlocks_next_core_exercise.rb
+++ b/app/services/unlocks_next_core_exercise.rb
@@ -9,12 +9,7 @@ class UnlocksNextCoreExercise
   def call
     return if core_exercises_in_progress?
 
-    next_exercise = track.
-      exercises.
-      joins("LEFT OUTER JOIN `solutions` ON `solutions`.`exercise_id` = `exercises`.`id` AND `solutions`.`user_id` = #{user.id}").
-      where(solutions: { id: nil }).
-      order(:position).
-      first
+    next_exercise = track.exercises.locked_for(user).order(:position).first
 
     if next_exercise
       UnlocksCoreExercise.(user, next_exercise)

--- a/app/services/unlocks_next_core_exercise.rb
+++ b/app/services/unlocks_next_core_exercise.rb
@@ -6,6 +6,8 @@ class UnlocksNextCoreExercise
   end
 
   def call
+    return if core_exercises_in_progress?
+
     next_exercise = exercise.track.exercises.where(core: true).
                       reorder('position ASC').
                       where("position > ?", exercise.position).
@@ -23,4 +25,13 @@ class UnlocksNextCoreExercise
 
   delegate :user, to: :solution
   delegate :exercise, to: :solution
+
+  def core_exercises_in_progress?
+    user.
+      solutions.
+      joins(:exercise).
+      where(exercises: { track: exercise.track, core: true }).
+      where(completed_at: nil).
+      exists?
+  end
 end

--- a/test/models/exercise_test.rb
+++ b/test/models/exercise_test.rb
@@ -15,4 +15,24 @@ class ExerciseTest < ActiveSupport::TestCase
 
     refute exercise.unlocked_by_user?(user)
   end
+
+  test "returns locked exercises for user" do
+    track = create(:track)
+    user = create(:user)
+    core_exercise = create(:exercise, track: track, core: true)
+    other_core_exercise = create(:exercise, track: track, core: true)
+    another_core_exercise = create(:exercise, track: track, core: true)
+    create(:solution,
+           user: user,
+           exercise: core_exercise,
+           completed_at: Date.new(2016, 12, 25))
+    create(:solution,
+           exercise: other_core_exercise,
+           completed_at: Date.new(2016, 12, 25))
+
+    assert_equal(
+      [other_core_exercise, another_core_exercise],
+      Exercise.locked_for(user)
+    )
+  end
 end

--- a/test/models/exercise_test.rb
+++ b/test/models/exercise_test.rb
@@ -1,0 +1,18 @@
+require_relative "../test_helper"
+
+class ExerciseTest < ActiveSupport::TestCase
+  test "an exercise is unlocked when a user has a solution for it" do
+    user = create(:user)
+    exercise = create(:exercise)
+    solution = create(:solution, user: user, exercise: exercise)
+
+    assert exercise.unlocked_by_user?(user)
+  end
+
+  test "an exercise is not unlocked when a user has no solution for it" do
+    user = create(:user)
+    exercise = create(:exercise)
+
+    refute exercise.unlocked_by_user?(user)
+  end
+end

--- a/test/services/completes_solution_test.rb
+++ b/test/services/completes_solution_test.rb
@@ -19,17 +19,14 @@ class CompletesSolutionTest < ActiveSupport::TestCase
       user = create :user
       mentor = create :user
       solution = create :solution, user: user, exercise: @core_exercise, approved_by: mentor
+      UnlocksNextCoreExercise.expects(:call).with(solution)
 
       CompletesSolution.complete!(solution)
 
       assert_equal DateTime.now.to_i, solution.completed_at.to_i
 
-      assert Solution.where(user: user, exercise: @next_core_exercise).exists?
       assert Solution.where(user: user, exercise: @side_exercise).exists?
-
       refute Solution.where(user: user, exercise: @other_side_exercise).exists?
-      refute Solution.where(user: user, exercise: @other_core_exercise).exists?
-      refute Solution.where(user: user, exercise: @another_core_exercise).exists?
     end
   end
 
@@ -57,18 +54,6 @@ class CompletesSolutionTest < ActiveSupport::TestCase
       user = create :user
       mentor = create :user
       create :solution, user: user, exercise: @side_exercise
-      solution = create :solution, user: user, exercise: @core_exercise, approved_by: mentor
-
-      CompletesSolution.complete!(solution)
-      assert_equal 1, Solution.where(user: user, exercise: @next_core_exercise).count
-    end
-  end
-
-  test "does not double-unlock core" do
-    Timecop.freeze do
-      user = create :user
-      mentor = create :user
-      create :solution, user: user, exercise: @next_core_exercise
       solution = create :solution, user: user, exercise: @core_exercise, approved_by: mentor
 
       CompletesSolution.complete!(solution)

--- a/test/services/completes_solution_test.rb
+++ b/test/services/completes_solution_test.rb
@@ -2,11 +2,11 @@ require 'test_helper'
 
 class CompletesSolutionTest < ActiveSupport::TestCase
   setup do
-    track = create :track
-    @core_exercise = create :exercise, track: track, core: true, position: 1
-    @other_core_exercise = create :exercise, track: track, core: true, position: 3
-    @next_core_exercise = create :exercise, track: track, core: true, position: 2
-    @another_core_exercise = create :exercise, track: track, core: true, position: 4
+    @track = create :track
+    @core_exercise = create :exercise, track: @track, core: true, position: 1
+    @other_core_exercise = create :exercise, track: @track, core: true, position: 3
+    @next_core_exercise = create :exercise, track: @track, core: true, position: 2
+    @another_core_exercise = create :exercise, track: @track, core: true, position: 4
 
     @side_exercise = create :exercise, core: false, unlocked_by: @core_exercise
     @other_side_exercise = create :exercise, core: false, unlocked_by: create(:exercise)
@@ -19,7 +19,7 @@ class CompletesSolutionTest < ActiveSupport::TestCase
       user = create :user
       mentor = create :user
       solution = create :solution, user: user, exercise: @core_exercise, approved_by: mentor
-      UnlocksNextCoreExercise.expects(:call).with(solution)
+      UnlocksNextCoreExercise.expects(:call).with(@track, user)
 
       CompletesSolution.complete!(solution)
 

--- a/test/services/unlocks_core_exercise_test.rb
+++ b/test/services/unlocks_core_exercise_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class UnlocksCoreExerciseTest < ActiveSupport::TestCase
+  test "unlocks core exercise" do
+    user = create(:user)
+    exercise = create(:exercise)
+    CreatesSolution.expects(:create!).with(user, exercise)
+
+    UnlocksCoreExercise.(user, exercise)
+  end
+
+  test "does not double-unlock" do
+    user = create(:user)
+    exercise = create(:exercise)
+    create(:solution, user: user, exercise: exercise)
+    CreatesSolution.expects(:create!).with(user, exercise).never
+
+    UnlocksCoreExercise.(user, exercise)
+  end
+end

--- a/test/services/unlocks_next_core_exercise_test.rb
+++ b/test/services/unlocks_next_core_exercise_test.rb
@@ -1,6 +1,25 @@
 require "test_helper"
 
 class UnlocksNextCoreExerciseTest < ActiveSupport::TestCase
+  test "unlocks a new core exercise only when all in progress core exercises are completed" do
+    track = create(:track)
+    user = create(:user)
+    core_exercise = create(:exercise, track: track, core: true, position: 1)
+    old_core_exercise = create(:exercise, track: track, core: true)
+    next_core_exercise = create(:exercise, track: track, core: true, position: 2)
+    create(:solution,
+           user: user,
+           exercise: old_core_exercise,
+           completed_at: nil)
+    solution = create(:solution,
+                      user: user,
+                      exercise: core_exercise,
+                      completed_at: Date.new(2016, 12, 25))
+    UnlocksCoreExercise.expects(:call).with(user, next_core_exercise).never
+
+    UnlocksNextCoreExercise.(solution)
+  end
+
   test "unlocks next core exercise" do
     track = create(:track)
     user = create(:user)
@@ -16,7 +35,10 @@ class UnlocksNextCoreExerciseTest < ActiveSupport::TestCase
                                 track: track,
                                 core: true,
                                 position: 3)
-    solution = create(:solution, user: user, exercise: core_exercise)
+    solution = create(:solution,
+                      user: user,
+                      exercise: core_exercise,
+                      completed_at: Date.new(2016, 12, 25))
     UnlocksCoreExercise.expects(:call).with(user, next_core_exercise)
     UnlocksCoreExercise.expects(:call).with(user, other_core_exercise).never
 

--- a/test/services/unlocks_next_core_exercise_test.rb
+++ b/test/services/unlocks_next_core_exercise_test.rb
@@ -11,13 +11,13 @@ class UnlocksNextCoreExerciseTest < ActiveSupport::TestCase
            user: user,
            exercise: old_core_exercise,
            completed_at: nil)
-    solution = create(:solution,
-                      user: user,
-                      exercise: core_exercise,
-                      completed_at: Date.new(2016, 12, 25))
+    create(:solution,
+           user: user,
+           exercise: core_exercise,
+           completed_at: Date.new(2016, 12, 25))
     UnlocksCoreExercise.expects(:call).with(user, next_core_exercise).never
 
-    UnlocksNextCoreExercise.(solution)
+    UnlocksNextCoreExercise.(track, user)
   end
 
   test "unlocks next core exercise" do
@@ -35,14 +35,14 @@ class UnlocksNextCoreExerciseTest < ActiveSupport::TestCase
                                 track: track,
                                 core: true,
                                 position: 3)
-    solution = create(:solution,
-                      user: user,
-                      exercise: core_exercise,
-                      completed_at: Date.new(2016, 12, 25))
+    create(:solution,
+           user: user,
+           exercise: core_exercise,
+           completed_at: Date.new(2016, 12, 25))
     UnlocksCoreExercise.expects(:call).with(user, next_core_exercise)
     UnlocksCoreExercise.expects(:call).with(user, other_core_exercise).never
 
-    UnlocksNextCoreExercise.(solution)
+    UnlocksNextCoreExercise.(track, user)
   end
 
   test "unlocks oldest core exercise not completed" do
@@ -60,16 +60,16 @@ class UnlocksNextCoreExerciseTest < ActiveSupport::TestCase
                                 track: track,
                                 core: true,
                                 position: 3)
-    solution = create(:solution,
-                      user: user,
-                      exercise: core_exercise,
-                      completed_at: Date.new(2016, 12, 25))
+    create(:solution,
+           user: user,
+           exercise: core_exercise,
+           completed_at: Date.new(2016, 12, 25))
     create(:solution,
            exercise: old_core_exercise,
            completed_at: Date.new(2016, 12, 25))
     UnlocksCoreExercise.expects(:call).with(user, old_core_exercise)
     UnlocksCoreExercise.expects(:call).with(user, next_core_exercise).never
 
-    UnlocksNextCoreExercise.(solution)
+    UnlocksNextCoreExercise.(track, user)
   end
 end

--- a/test/services/unlocks_next_core_exercise_test.rb
+++ b/test/services/unlocks_next_core_exercise_test.rb
@@ -21,8 +21,8 @@ class UnlocksNextCoreExerciseTest < ActiveSupport::TestCase
 
     UnlocksNextCoreExercise.(solution)
 
-    assert Solution.where(user: user, exercise: next_core_exercise).exists?
-    refute Solution.where(user: user, exercise: other_core_exercise).exists?
+    assert next_core_exercise.unlocked_by_user?(user)
+    refute other_core_exercise.unlocked_by_user?(user)
   end
 
   test "does not double-unlock core" do

--- a/test/services/unlocks_next_core_exercise_test.rb
+++ b/test/services/unlocks_next_core_exercise_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+class UnlocksNextCoreExerciseTest < ActiveSupport::TestCase
+  test "unlocks next core exercise" do
+    Git::ExercismRepo.stubs(current_head: "dummy-sha1")
+    track = create(:track)
+    user = create(:user)
+    core_exercise = create(:exercise,
+                           track: track,
+                           core: true,
+                           position: 1)
+    next_core_exercise = create(:exercise,
+                                track: track,
+                                core: true,
+                                position: 2)
+    other_core_exercise = create(:exercise,
+                                track: track,
+                                core: true,
+                                position: 3)
+    solution = create(:solution, user: user, exercise: core_exercise)
+
+    UnlocksNextCoreExercise.(solution)
+
+    assert Solution.where(user: user, exercise: next_core_exercise).exists?
+    refute Solution.where(user: user, exercise: other_core_exercise).exists?
+  end
+
+  test "does not double-unlock core" do
+    track = create(:track)
+    user = create(:user)
+    core_exercise = create(:exercise,
+                           track: track,
+                           core: true,
+                           position: 1)
+    next_core_exercise = create(:exercise,
+                                track: track,
+                                core: true,
+                                position: 2)
+    create(:solution, user: user, exercise: next_core_exercise)
+    solution = create(:solution, user: user, exercise: core_exercise)
+
+    UnlocksNextCoreExercise.(solution)
+
+    assert_equal 1, Solution.where(user: user, exercise: next_core_exercise).count
+  end
+end

--- a/test/services/unlocks_next_core_exercise_test.rb
+++ b/test/services/unlocks_next_core_exercise_test.rb
@@ -2,7 +2,6 @@ require "test_helper"
 
 class UnlocksNextCoreExerciseTest < ActiveSupport::TestCase
   test "unlocks next core exercise" do
-    Git::ExercismRepo.stubs(current_head: "dummy-sha1")
     track = create(:track)
     user = create(:user)
     core_exercise = create(:exercise,
@@ -18,29 +17,10 @@ class UnlocksNextCoreExerciseTest < ActiveSupport::TestCase
                                 core: true,
                                 position: 3)
     solution = create(:solution, user: user, exercise: core_exercise)
+    UnlocksCoreExercise.expects(:call).with(user, next_core_exercise)
+    UnlocksCoreExercise.expects(:call).with(user, other_core_exercise).never
 
     UnlocksNextCoreExercise.(solution)
-
-    assert next_core_exercise.unlocked_by_user?(user)
-    refute other_core_exercise.unlocked_by_user?(user)
   end
 
-  test "does not double-unlock core" do
-    track = create(:track)
-    user = create(:user)
-    core_exercise = create(:exercise,
-                           track: track,
-                           core: true,
-                           position: 1)
-    next_core_exercise = create(:exercise,
-                                track: track,
-                                core: true,
-                                position: 2)
-    create(:solution, user: user, exercise: next_core_exercise)
-    solution = create(:solution, user: user, exercise: core_exercise)
-
-    UnlocksNextCoreExercise.(solution)
-
-    assert_equal 1, Solution.where(user: user, exercise: next_core_exercise).count
-  end
 end

--- a/test/services/unlocks_next_core_exercise_test.rb
+++ b/test/services/unlocks_next_core_exercise_test.rb
@@ -64,9 +64,6 @@ class UnlocksNextCoreExerciseTest < ActiveSupport::TestCase
            user: user,
            exercise: core_exercise,
            completed_at: Date.new(2016, 12, 25))
-    create(:solution,
-           exercise: old_core_exercise,
-           completed_at: Date.new(2016, 12, 25))
     UnlocksCoreExercise.expects(:call).with(user, old_core_exercise)
     UnlocksCoreExercise.expects(:call).with(user, next_core_exercise).never
 

--- a/test/services/unlocks_next_core_exercise_test.rb
+++ b/test/services/unlocks_next_core_exercise_test.rb
@@ -45,4 +45,31 @@ class UnlocksNextCoreExerciseTest < ActiveSupport::TestCase
     UnlocksNextCoreExercise.(solution)
   end
 
+  test "unlocks oldest core exercise not completed" do
+    track = create(:track)
+    user = create(:user)
+    core_exercise = create(:exercise,
+                           track: track,
+                           core: true,
+                           position: 2)
+    old_core_exercise = create(:exercise,
+                                track: track,
+                                core: true,
+                                position: 1)
+    next_core_exercise = create(:exercise,
+                                track: track,
+                                core: true,
+                                position: 3)
+    solution = create(:solution,
+                      user: user,
+                      exercise: core_exercise,
+                      completed_at: Date.new(2016, 12, 25))
+    create(:solution,
+           exercise: old_core_exercise,
+           completed_at: Date.new(2016, 12, 25))
+    UnlocksCoreExercise.expects(:call).with(user, old_core_exercise)
+    UnlocksCoreExercise.expects(:call).with(user, next_core_exercise).never
+
+    UnlocksNextCoreExercise.(solution)
+  end
 end


### PR DESCRIPTION
Finishes part of https://github.com/exercism/reboot/issues/123.

## Description
This PR changes how we unlock the next core exercise.

1. Don't unlock the next core exercise when there are still other core exercises in progress.
2. Unlock the core exercise with the lowest position that hasn't been completed yet.