### PR TITLE
Allow user to leave a track

### DIFF
--- a/app/assets/stylesheets/pages/my-track.scss
+++ b/app/assets/stylesheets/pages/my-track.scss
@@ -269,7 +269,7 @@ body.namespace-my.controller-tracks.action-show {
             margin-bottom:30px;
             text-align:right;
         }
-        .core, .topics, .side {
+        .core, .topics, .side, .danger-zone {
             background:#fff;
             padding:20px 30px;
             margin-bottom:15px;
@@ -352,6 +352,23 @@ body.namespace-my.controller-tracks.action-show {
                     width:20%;
                     text-align:right;
                     float:right;
+                }
+            }
+        }
+        .danger-zone {
+            .leave-track-btn {
+                display:block;
+                background:#fff;
+                color:$color-1;
+                border:1px solid rgba($color-1, 0.5);
+                @include font-size(12, 12);
+                padding:9px;
+                width:100%;
+                margin:10px 0;
+                &:hover {
+                    background:$color-1;
+                    border-color:$color-1;
+                    color:#fff;
                 }
             }
         }

--- a/app/assets/stylesheets/pages/my-track.scss
+++ b/app/assets/stylesheets/pages/my-track.scss
@@ -460,7 +460,8 @@ body.namespace-my.controller-tracks.action-show {
 #modal.my-track-started,
 #modal.my-track-finished,
 #modal.my-track-v1-migration,
-#modal.change-to-independent-mode {
+#modal.change-to-independent-mode,
+#modal.leave-track {
     max-width:540px;
     padding:50px 50px 50px 50px;
     img {
@@ -571,7 +572,8 @@ body.namespace-my.controller-tracks.action-show {
     }
 }
 
-#modal.change-to-independent-mode {
+#modal.change-to-independent-mode,
+#modal.leave-track {
     .pure-button {
         margin: 0 auto;
 
@@ -581,10 +583,10 @@ body.namespace-my.controller-tracks.action-show {
         padding: 10px 13px;
         font-weight:400;
 
-        &.independent-mode {
+        &.action-button {
             width:69%;
         }
-        &.cancel {
+        &.cancel-button {
             border:1px solid $color-1;
             background:#fff;
             color:$color-1;

--- a/app/assets/stylesheets/pages/my-track.scss
+++ b/app/assets/stylesheets/pages/my-track.scss
@@ -356,7 +356,8 @@ body.namespace-my.controller-tracks.action-show {
             }
         }
         .danger-zone {
-            .leave-track-btn {
+            .leave-track-btn,
+            .change-to-independent-btn {
                 display:block;
                 background:#fff;
                 color:$color-1;
@@ -458,7 +459,9 @@ body.namespace-my.controller-tracks.action-show {
 
 #modal.my-track-started,
 #modal.my-track-finished,
-#modal.my-track-v1-migration {
+#modal.my-track-v1-migration,
+#modal.change-to-independent-mode {
+    max-width:540px;
     padding:50px 50px 50px 50px;
     img {
         display:block;
@@ -564,6 +567,29 @@ body.namespace-my.controller-tracks.action-show {
             color:$color-1;
             font-weight:300;
             width:40%;
+        }
+    }
+}
+
+#modal.change-to-independent-mode {
+    .pure-button {
+        margin: 0 auto;
+
+        display:inline-block;
+        width:auto;
+        border:1px solid $color-1;
+        padding: 10px 13px;
+        font-weight:400;
+
+        &.independent-mode {
+            width:69%;
+        }
+        &.cancel {
+            border:1px solid $color-1;
+            background:#fff;
+            color:$color-1;
+            font-weight:300;
+            width:30%;
         }
     }
 }

--- a/app/controllers/my/tracks_controller.rb
+++ b/app/controllers/my/tracks_controller.rb
@@ -4,7 +4,7 @@ class My::TracksController < MyController
   def index
     tracks = Track.active.order('title ASC')
     tracks = tracks.where("title like ?", "%#{params[:title]}%") if params[:title].present?
-    joined_track_ids = current_user.user_tracks.pluck(:track_id)
+    joined_track_ids = current_user.user_tracks.unarchived.pluck(:track_id)
 
     @joined_tracks, @other_tracks = tracks.partition {|t|joined_track_ids.include?(t.id)}
     @completed_exercise_counts = current_user.solutions.completed.joins(:exercise).group(:track_id).count

--- a/app/controllers/my/user_tracks_controller.rb
+++ b/app/controllers/my/user_tracks_controller.rb
@@ -1,7 +1,15 @@
 class My::UserTracksController < MyController
   def create
     track = Track.find(params[:track_id])
-    JoinsTrack.join!(current_user, track)
+
+    if current_user.previously_joined_track?(track)
+      user_track = current_user.user_tracks.find_by(track: track)
+
+      user_track.update!(archived_at: nil)
+    else
+      JoinsTrack.join!(current_user, track)
+    end
+
     redirect_to [:my, track]
   end
 

--- a/app/controllers/my/user_tracks_controller.rb
+++ b/app/controllers/my/user_tracks_controller.rb
@@ -18,4 +18,11 @@ class My::UserTracksController < MyController
     redirect_to [:my, track]
   end
 
+  def leave
+    user_track = current_user.user_tracks.find(params[:id])
+
+    user_track.update(archived_at: Time.current)
+
+    redirect_to my_tracks_path
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -81,6 +81,13 @@ class User < ApplicationRecord
     false
   end
 
+  def previously_joined_track?(track)
+    user_tracks.
+      archived.
+      where(track_id: track.id).
+      exists?
+  end
+
   def joined_track?(track)
     user_tracks.where(track_id: track.id).exists?
   end

--- a/app/models/user_track.rb
+++ b/app/models/user_track.rb
@@ -29,4 +29,8 @@ class UserTrack < ApplicationRecord
     user.solutions.joins(:exercise).
                    where("exercises.track_id": track_id)
   end
+
+  def archived?
+    archived_at.present?
+  end
 end

--- a/app/models/user_track.rb
+++ b/app/models/user_track.rb
@@ -4,6 +4,8 @@ class UserTrack < ApplicationRecord
 
   validates :handle, handle: true
 
+  scope :unarchived, -> { where(archived_at: nil) }
+
   def originated_in_v1?
     created_at < Exercism::V2_MIGRATED_AT
   end

--- a/app/models/user_track.rb
+++ b/app/models/user_track.rb
@@ -4,6 +4,7 @@ class UserTrack < ApplicationRecord
 
   validates :handle, handle: true
 
+  scope :archived, -> { where.not(archived_at: nil) }
   scope :unarchived, -> { where(archived_at: nil) }
 
   def originated_in_v1?

--- a/app/views/my/tracks/_change_to_independent_mode_modal.html.haml
+++ b/app/views/my/tracks/_change_to_independent_mode_modal.html.haml
@@ -1,0 +1,9 @@
+=hex_green_track_icon(track)
+.main-section
+  %h2 Switch to Independent Mode
+  %h3 on the #{track.title} Track
+
+  %p In Independent Mode all of the exercises within a Track are unlocked and students can work through them freely. Note that in this mode Mentor feedback is disabled. This mode is for people who want to do fast deep-dives into a track and is not recommended for those that want the full Exercism experience.
+  .buttons
+    =link_to "Independent Mode", set_independent_mode_my_user_track_path(@user_track), method: :patch, class: 'pure-button independent-mode'
+    =link_to "Cancel", "#", class: "pure-button close-modal cancel"

--- a/app/views/my/tracks/_change_to_independent_mode_modal.html.haml
+++ b/app/views/my/tracks/_change_to_independent_mode_modal.html.haml
@@ -5,5 +5,6 @@
 
   %p In Independent Mode all of the exercises within a Track are unlocked and students can work through them freely. Note that in this mode Mentor feedback is disabled. This mode is for people who want to do fast deep-dives into a track and is not recommended for those that want the full Exercism experience.
   .buttons
-    =link_to "Independent Mode", set_independent_mode_my_user_track_path(@user_track), method: :patch, class: 'pure-button independent-mode'
-    =link_to "Cancel", "#", class: "pure-button close-modal cancel"
+    / TODO - kntsoriano
+    =link_to "Independent Mode", set_independent_mode_my_user_track_path(@user_track), method: :patch, class: 'pure-button action-button'
+    =link_to "Cancel", "#", class: "pure-button close-modal cancel-button"

--- a/app/views/my/tracks/_leave_track_modal.html.haml
+++ b/app/views/my/tracks/_leave_track_modal.html.haml
@@ -1,0 +1,9 @@
+=hex_green_track_icon(track)
+.main-section
+  %h2 Leave the #{track.title} Track
+
+  %p Leaving this track will remove it from your list of tracks and remove your progress. Are you sure you want to continue?
+  .buttons
+    =link_to "Leave Track", set_independent_mode_my_user_track_path(@user_track), method: :patch, class: 'pure-button action-button'
+    =link_to "Cancel", "#", class: "pure-button close-modal cancel-button"
+

--- a/app/views/my/tracks/_leave_track_modal.html.haml
+++ b/app/views/my/tracks/_leave_track_modal.html.haml
@@ -4,6 +4,6 @@
 
   %p Leaving this track will remove it from your list of tracks and remove your progress. Are you sure you want to continue?
   .buttons
-    =link_to "Leave Track", set_independent_mode_my_user_track_path(@user_track), method: :patch, class: 'pure-button action-button'
+    =link_to "Leave Track", leave_my_user_track_path(@user_track), method: :post, class: 'pure-button action-button'
     =link_to "Cancel", "#", class: "pure-button close-modal cancel-button"
 

--- a/app/views/my/tracks/_show_normal_mode.html.haml
+++ b/app/views/my/tracks/_show_normal_mode.html.haml
@@ -36,5 +36,14 @@
           .danger-zone
             %h3 Danger Zone
             =link_to "Leave Track", "#", class: 'pure-button leave-track-btn'
+            -if !@user_track.independent_mode?
+              =link_to "Switch to Independent Mode", "#", class: 'pure-button change-to-independent-btn'
 
 =render "show_side_exercises", exercises_and_solutions: @side_exercises_and_solutions
+
+-if !@user_track.independent_mode?
+  -content_for :js do
+    :javascript
+      $('.change-to-independent-btn').click(function() {
+        showModal("change-to-independent-mode", "#{j(render "change_to_independent_mode_modal", track: @track)}")
+      })

--- a/app/views/my/tracks/_show_normal_mode.html.haml
+++ b/app/views/my/tracks/_show_normal_mode.html.haml
@@ -41,6 +41,12 @@
 
 =render "show_side_exercises", exercises_and_solutions: @side_exercises_and_solutions
 
+-content_for :js do
+  :javascript
+    $('.leave-track-btn').click(function() {
+      showModal("leave-track", "#{j(render "leave_track_modal", track: @track)}")
+    })
+
 -if !@user_track.independent_mode?
   -content_for :js do
     :javascript

--- a/app/views/my/tracks/_show_normal_mode.html.haml
+++ b/app/views/my/tracks/_show_normal_mode.html.haml
@@ -33,5 +33,8 @@
               =link_to "Show More", "#", class: 'pure-button extra-button'
               .extra
                 =render "topic_percentages", topic_percentages: @topic_percentages[11..-1]
+          .danger-zone
+            %h3 Danger Zone
+            =link_to "Leave Track", "#", class: 'pure-button leave-track-btn'
 
 =render "show_side_exercises", exercises_and_solutions: @side_exercises_and_solutions

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -97,6 +97,7 @@ Rails.application.routes.draw do
       member do
         patch :set_normal_mode
         patch :set_independent_mode
+        post :leave
       end
     end
     resources :solutions, only: [:show, :create] do

--- a/db/migrate/20180707132112_add_archived_at_to_user_tracks.rb
+++ b/db/migrate/20180707132112_add_archived_at_to_user_tracks.rb
@@ -1,0 +1,5 @@
+class AddArchivedAtToUserTracks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :user_tracks, :archived_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_21_150555) do
+ActiveRecord::Schema.define(version: 2018_07_07_132112) do
 
   create_table "auth_tokens", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -355,6 +355,7 @@ ActiveRecord::Schema.define(version: 2018_06_21_150555) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "independent_mode"
+    t.datetime "archived_at"
     t.index ["track_id", "user_id"], name: "index_user_tracks_on_track_id_and_user_id", unique: true
     t.index ["user_id"], name: "fk_rails_99e944edbc"
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -10,6 +10,20 @@ class UserTest < ActiveSupport::TestCase
     assert user.joined_track?(track)
   end
 
+  test "previously joined track" do
+    user = create(:user)
+    previously_joined = create(:track)
+    currently_joined = create(:track)
+    create(:user_track,
+           user: user,
+           track: previously_joined,
+           archived_at: Date.new(2016, 12, 25))
+    create(:user_track, track: currently_joined, user: user, archived_at: nil)
+
+    assert user.previously_joined_track?(previously_joined)
+    refute user.previously_joined_track?(currently_joined)
+  end
+
   test "mentor?" do
     user = create :user
     refute user.mentor?

--- a/test/models/user_track_test.rb
+++ b/test/models/user_track_test.rb
@@ -49,4 +49,11 @@ class UserTrackTest < ActiveSupport::TestCase
 
     assert_equal [unarchived], UserTrack.unarchived
   end
+
+  test "archived user tracks" do
+    archived = create(:user_track, archived_at: Date.new(2016, 12, 25))
+    unarchived = create(:user_track, archived_at: nil)
+
+    assert_equal [archived], UserTrack.archived
+  end
 end

--- a/test/models/user_track_test.rb
+++ b/test/models/user_track_test.rb
@@ -42,4 +42,11 @@ class UserTrackTest < ActiveSupport::TestCase
     assert archived.archived?
     refute unarchived.archived?
   end
+
+  test "unarchived user tracks" do
+    archived = create(:user_track, archived_at: Date.new(2016, 12, 25))
+    unarchived = create(:user_track, archived_at: nil)
+
+    assert_equal [unarchived], UserTrack.unarchived
+  end
 end

--- a/test/models/user_track_test.rb
+++ b/test/models/user_track_test.rb
@@ -34,4 +34,12 @@ class UserTrackTest < ActiveSupport::TestCase
     assert old.originated_in_v1?
     refute new.originated_in_v1?
   end
+
+  test "archived?" do
+    archived = build(:user_track, archived_at: Date.new(2016, 12, 25))
+    unarchived = build(:user_track, archived_at: nil)
+
+    assert archived.archived?
+    refute unarchived.archived?
+  end
 end

--- a/test/system/join_track_test.rb
+++ b/test/system/join_track_test.rb
@@ -1,0 +1,29 @@
+class JoinTrackTest < ApplicationSystemTestCase
+  test "user rejoins a track" do
+    user = create(:user)
+    track = create(:track,
+                   title: "Ruby",
+                   repo_url: "file://#{Rails.root}/test/fixtures/website-copy")
+    exercise = create(:exercise,
+                      track: track,
+                      title: "Hello World",
+                      core: true)
+    solution = create(:solution,
+                      user: user,
+                      exercise: exercise,
+                      completed_at: Date.new(2016, 12, 25))
+    create(:user_track,
+           user: user,
+           track: track,
+           independent_mode: false,
+           archived_at: Date.new(2016, 12, 25))
+
+    stub_repo_cache! do
+      sign_in!(user)
+      visit my_track_path(track)
+      click_on "Join the Ruby track"
+    end
+
+    within(".exercise.completed") { assert_text "Hello World" }
+  end
+end

--- a/test/system/leave_track_test.rb
+++ b/test/system/leave_track_test.rb
@@ -1,0 +1,20 @@
+require "application_system_test_case"
+
+class LeaveTrackTest < ApplicationSystemTestCase
+  test "user leaves a track" do
+    user = create(:user)
+    track = create(:track, title: "Ruby")
+    create(:user_track,
+           user: user,
+           track: track,
+           independent_mode: false)
+
+    sign_in!(user)
+    visit track_path(track)
+    click_on "Leave Track"
+    click_on "Leave Track"
+
+    within(".other-tracks") { assert_text "Ruby" }
+    assert_no_css ".joined-tracks"
+  end
+end


### PR DESCRIPTION
Closes https://github.com/exercism/reboot/issues/72.

## Description
This PR allows a user to leave and rejoin a track. As we want to support rejoining a track, an `archived_at` attribute was added to `UserTrack` in order to determine whether a user has temporarily left the track. No data will be deleted and rejoining the track will simply be turning `archived_at` to `nil`.