### PR TITLE
Verify webhooks from Github push events

### DIFF
--- a/app/controllers/webhooks/repo_updates_controller.rb
+++ b/app/controllers/webhooks/repo_updates_controller.rb
@@ -1,4 +1,6 @@
 class Webhooks::RepoUpdatesController < WebhooksController
+  before_action :verify_github_webhook
+
   MASTER_REF = "refs/heads/master"
 
   def create
@@ -17,5 +19,25 @@ class Webhooks::RepoUpdatesController < WebhooksController
 
   def slug
     params.fetch(:repository).fetch(:name)
+  end
+
+  def verify_github_webhook
+    payload = request.raw_post
+    signature = 'sha1=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), secret, payload)
+    if !Rack::Utils.secure_compare(signature, github_signature)
+      render json: {error: 'invalid signature - delivery: %s' % github_delivery}, status: 500
+    end
+  end
+
+  def secret
+    ENV['GITHUB_WEBHOOK_SECRET'] || 'hot fudge sundae' # default for test env
+  end
+
+  def github_signature
+    request.env['HTTP_X_HUB_SIGNATURE']
+  end
+
+  def github_delivery
+    request.headers['HTTP_X_GITHUB_DELIVERY']
   end
 end

--- a/test/controllers/webhooks/repo_updates_controller_test.rb
+++ b/test/controllers/webhooks/repo_updates_controller_test.rb
@@ -9,7 +9,7 @@ class Webhooks::RepoUpdatesControllerTest < ActionDispatch::IntegrationTest
     webhook["ref"] = "refs/heads/master"
     webhook["repository"]["name"] = "ruby"
 
-    post webhooks_repo_updates_path, params: webhook
+    post webhooks_repo_updates_path, default_options(webhook)
 
     repo_update = RepoUpdate.last
     assert_equal "ruby", repo_update.slug
@@ -18,7 +18,7 @@ class Webhooks::RepoUpdatesControllerTest < ActionDispatch::IntegrationTest
   test "create should not create a RepoUpdate when not pushed to master" do
     webhook = load_json("test/fixtures/github/push_event.json")
 
-    post webhooks_repo_updates_path, params: webhook
+    post webhooks_repo_updates_path, default_options(webhook)
 
     assert_nil RepoUpdate.last
   end
@@ -28,14 +28,42 @@ class Webhooks::RepoUpdatesControllerTest < ActionDispatch::IntegrationTest
     webhook["ref"] = "refs/heads/master"
     webhook["repository"]["name"] = "unknown"
 
-    post webhooks_repo_updates_path, params: webhook
+    post webhooks_repo_updates_path, default_options(webhook)
 
     assert_nil RepoUpdate.last
+  end
+
+  test "it doesn't process a request with an invalid signature" do
+    webhook = load_json("test/fixtures/github/push_event.json")
+    options = default_options(webhook)
+    options[:headers]['X-Hub-Signature'] = 'ZOMG wrong signature'
+
+    post webhooks_repo_updates_path, options
+
+    assert_equal 500, response.status
+    assert_match "abc-123", JSON.parse(response.body)['error']
+    assert_match "invalid signature", JSON.parse(response.body)['error']
   end
 
   private
 
   def load_json(file)
     JSON.parse(File.read(file))
+  end
+
+  def default_options(payload)
+    {
+      headers: {
+        'X-GitHub-Delivery' => 'abc-123',
+        # Signature is pre-calculated to match the post body 'fake'.
+        # Under normal circumstances, the request.raw_post is the actual raw
+        # post body that was received.
+        'X-Hub-Signature' => 'sha1=cfbe1b6a0950b651e6f07e951476bb818051ae16',
+      },
+      env: {
+        'action_dispatch.request.request_parameters' => payload,
+        'action_dispatch.request.raw_post' => 'fake',
+      }
+    }
   end
 end


### PR DESCRIPTION
Closes https://github.com/exercism/reboot/issues/146.

There was already existing code for this in the contributions controller. I just copied and pasted it.