### PR TITLE
Remove secrets from repository

### DIFF
--- a/app/models/git/github_profile.rb
+++ b/app/models/git/github_profile.rb
@@ -1,10 +1,10 @@
 class Git::GithubProfile
 
   def self.for_user(username)
-    auth_config = Rails.application.config_for("auth")
-    github_key = auth_config["github_key"]
-    github_secret = auth_config["github_secret"]
-    client = Octokit::Client.new(client_id: github_key, client_secret: github_secret)
+    client = Octokit::Client.new(
+      client_id: Rails.application.secrets.github_key,
+      client_secret: Rails.application.secrets.github_secret
+    )
     user = client.user(username)
     self.new(user)
   end

--- a/config/auth.yml
+++ b/config/auth.yml
@@ -1,7 +1,0 @@
-development:
-  github_key: f19303e181ab6a2b6413
-  github_secret: d077b52d7432e3f95d474b64af2a32f1e7a36ac5
-
-production:
-  github_key: LIVE-KEY-HERE
-  github_secret: LIVE-SECRET-HERE

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -7,7 +7,7 @@ set :application, @application
 set :repo_url, "git@github.com:exercism/prototype.git"
 set :branch, 'master'
 
-set :linked_files, %w{config/database.yml config/auth.yml config/smtp.yml}
+set :linked_files, %w{config/database.yml config/secrets.yml config/smtp.yml}
 set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'vendor/bundle', 'public/system', 'public/uploads')
 
 set :deploy_to, "/opt/#{@application}"

--- a/config/initializers/action_job.rb
+++ b/config/initializers/action_job.rb
@@ -1,4 +1,4 @@
 Rails.application.config.active_job.queue_adapter = :sidekiq
 Sidekiq.configure_client do |config|
-  config.redis = { url: 'redis://processor.exercism.io:6379/0' } if Rails.env.production?
+  config.redis = { url: Rails.application.secrets.redis_url } if Rails.env.production?
 end

--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -1,4 +1,4 @@
 Bugsnag.configure do |config|
-  config.api_key = "ba0c39df0e6cd8eb2f1bec106b8bc09c"
+  config.api_key = Rails.application.secrets.bugsnag_api_key
   config.notify_release_stages = ["staging", "production"]
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -6,7 +6,7 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  config.secret_key = 'b429a6673554c258fdddd028a737afa0d82c0e9478b889ed5dcdeff59d0b47e8825c35d31b418231731b230fce19bbdd3a8d04c653c02cca0785c5d385ef7887'
+  # config.secret_key = 'USE_RAILS_SECRET_KEY'
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -250,11 +250,10 @@ Devise.setup do |config|
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
-  auth_config = Rails.application.config_for("auth")
-
-  github_key = auth_config["github_key"]
-  github_secret = auth_config["github_secret"]
-  config.omniauth :github, github_key, github_secret, scope: "user:email"
+  config.omniauth :github,
+    Rails.application.secrets.github_key,
+    Rails.application.secrets.github_secret,
+    scope: "user:email"
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,21 +1,5 @@
-# Be sure to restart your server when you modify this file.
-
-# Your secret key is used for verifying the integrity of signed cookies.
-# If you change this key, all old signed cookies will become invalid!
-
-# Make sure the secret is at least 30 characters and all random,
-# no regular words or you'll be exposed to dictionary attacks.
-# You can use `rails secret` to generate a secure secret key.
-
-# Make sure the secrets in this file are kept private
-# if you're sharing your code publicly.
-
-# Shared secrets are available across all environments.
-
-# shared:
-#   api_key: a1B2c3D4e5F6
-
-# Environmental secrets are only available for that specific environment.
+# This file only provides the secrets for the development environment.
+# The production environment secrets filed gets copied in during deploy.
 
 development:
   secret_key_base: eac22c825e9b855087133488eec19eeff644b8bb25f7e6e359e847a2c2fe4366ff72e1543ce15ef9f2dc2b4bf6f095a5682d7b03af81f2706f888c74f06ba1ab

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -19,17 +19,8 @@
 
 development:
   secret_key_base: eac22c825e9b855087133488eec19eeff644b8bb25f7e6e359e847a2c2fe4366ff72e1543ce15ef9f2dc2b4bf6f095a5682d7b03af81f2706f888c74f06ba1ab
+  github_key: f19303e181ab6a2b6413
+  github_secret: d077b52d7432e3f95d474b64af2a32f1e7a36ac5
 
 test:
   secret_key_base: 60785574a657542ba208c881c80b06b30cf6b4d6ad57a2bb2deb4e0de315fa1256dc74bad3d4dd483a37f467c75412a143344e11ace332e8ab2eff254ef05f2c
-
-# Do not keep production secrets in the unencrypted secrets file.
-# Instead, either read values from the environment.
-# Or, use `bin/rails secrets:setup` to configure encrypted secrets
-# and move the `production:` environment over there.
-
-staging:
-  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
-
-production:
-  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>

--- a/config/smtp.yml
+++ b/config/smtp.yml
@@ -1,7 +1,0 @@
-development:
-  user_name: '3213fc4e9a3f2d38'
-  password: '18efa7fa812f69'
-  address: 'smtp.mailtrap.io'
-  domain: 'smtp.mailtrap.io'
-  port: '2525'
-  authentication: :cram_md5


### PR DESCRIPTION
Closes https://github.com/exercism/reboot/issues/277.

Instead of using `exercism.yml` as we previously agreed upon, I decided to use `secrets.yml` instead as Rails has built-in support for this. It should just function the same way as we've discussed.

All our secrets are now inside `secrets.yml` and will be copied in during our deployment. The necessary additions to our chef is here: https://github.com/ThalamusAI/exercism-chef/pull/4.