### PR TITLE
Remove copy widget from walkthrough

### DIFF
--- a/app/services/renders_user_walkthrough.rb
+++ b/app/services/renders_user_walkthrough.rb
@@ -20,10 +20,7 @@ class RendersUserWalkthrough
   def substitute_tokens!
     walkthrough.gsub!(
       CONFIGURE_COMMAND_TOKEN,
-      ApplicationController.render(
-        partial: "widgets/code_snippet",
-        locals: { code: configure_command(user.auth_token) }
-      )
+      configure_command(user.auth_token)
     )
   end
 

--- a/test/services/renders_user_walkthrough_test.rb
+++ b/test/services/renders_user_walkthrough_test.rb
@@ -12,9 +12,9 @@ class RendersUserWalkthroughTest < ActiveSupport::TestCase
     user = create(:user)
     auth_token = create(:auth_token, user: user, token: "TOKEN")
 
-    assert_includes(
-      RendersUserWalkthrough.(user, "[CONFIGURE_COMMAND]"),
-      "exercism configure --token=TOKEN"
+    assert_equal(
+      "exercism configure --token=TOKEN",
+      RendersUserWalkthrough.(user, "[CONFIGURE_COMMAND]")
     )
   end
 end


### PR DESCRIPTION
If we were to use the copy widget, we'd need to rebind the Javascript event that enables the copy button. Let's keep it simple for now.