### PR TITLE
Delete the pharo track until we get the syncing fixed

### DIFF
--- a/app/services/git/seeds_tracks.rb
+++ b/app/services/git/seeds_tracks.rb
@@ -48,7 +48,6 @@ class Git::SeedsTracks
     https://github.com/exercism/ocaml
     https://github.com/exercism/perl5
     https://github.com/exercism/perl6
-    https://github.com/exercism/pharo
     https://github.com/exercism/php
     https://github.com/exercism/plsql
     https://github.com/exercism/pony


### PR DESCRIPTION
The Pharo track does not yet have any exercises. The SyncsTrack code
assumes that the code has an array of exercises, and blows up when there
are none.

It is likely a very quick fix, but we have so many things on our minds
at the moment with launch, that it's simpler to just remove this one
problem and then we can put it back when we've sorted out the syncing.

FYI @iHiD @kntsoriano I'm merging this to unblock contributors.