### PR TITLE
Open the site to search engines

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,2 @@
-# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
 User-agent: *
-Disallow: /
+Disallow: /my/


### PR DESCRIPTION
Added disallow `/my` because they'll be 301s to the login form anyway and the extra load is wasteful

Closes https://github.com/exercism/reboot/issues/197